### PR TITLE
Prompt caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,16 @@ For maximum benefit, design your prompts such that repetitive content is placed 
 
 All repetitive content at the beginning of the prompt does not need to be processed by the LLM.
 
+Each caller of the llama_cpp_canister has it's own cache folder, and has the following endpoints available to manage their prompt-cache files:
+
+```bash
+# To remove a prompt cache file from the caller's cache folder
+dfx canister call llama_cpp remove_prompt_cache '(record { args = vec {"--prompt-cache"; "prompt.cache"} })'
+
+# To copy a prompt cache file within the caller's cache folder
+dfx canister call llama_cpp copy_prompt_cache '(record { from = "prompt.cache"; to = "prompt-save.cache"} })'
+```
+
 # Access control
 
 By default, only a controller can call the inference endpoints:

--- a/README.md
+++ b/README.md
@@ -272,20 +272,18 @@ You can run a smoketest on the deployed LLM:
 
 # Prompt Caching
 
-When you don't remove the prompt cache but leave it in place and then reuse it for your next chat, llama_cpp_canister automatically applies prompt caching to reduce latency and cost.
+When a prompt cache file is already present, llama_cpp_canister automatically applies prompt caching to reduce latency and cost.
 
-For maximum benefit, design your prompts such that repetitive content is placed at the beginning.
-
-All repetitive content at the beginning of the prompt does not need to be processed by the LLM.
+All repetitive content at the beginning of the prompt does not need to be processed by the LLM, so make sure to design your AI agent prompts such that repetitive content is placed at the beginning.
 
 Each caller of the llama_cpp_canister has it's own cache folder, and has the following endpoints available to manage their prompt-cache files:
 
 ```bash
-# To remove a prompt cache file from the caller's cache folder
+# Remove a prompt cache file from the caller's cache folder
 dfx canister call llama_cpp remove_prompt_cache '(record { args = vec {"--prompt-cache"; "prompt.cache"} })'
 
-# To copy a prompt cache file within the caller's cache folder
-dfx canister call llama_cpp copy_prompt_cache '(record { from = "prompt.cache"; to = "prompt-save.cache"} })'
+# Copy a prompt cache file within the caller's cache folder
+dfx canister call llama_cpp copy_prompt_cache '(record { from = "prompt.cache"; to = "prompt-save.cache"} )'
 ```
 
 # Access control

--- a/native/test_qwen2.cpp
+++ b/native/test_qwen2.cpp
@@ -95,7 +95,17 @@ void test_qwen2(MockIC &mockIC) {
   // Let's have two chats with this model
   for (int i = 0; i < 2; ++i) {
     // -----------------------------------------------------------------------------
-    // Start a new chat, which will remove the prompt-cache file if it exists
+    // Remove the prompt-cache file if it exists
+    // '(record { args = vec {"--prompt-cache"; "prompt.cache"} })' ->
+    // '(variant { Ok = record { status_code = 200 : nat16; output = "Cache file .canister_cache/expmt-gtxsw-inftj-ttabj-qhp5s-nozup-n3bbo-k7zvn-dg4he-knac3-lae/sessions/prompt.cache deleted successfully"; input = ""; error=""; prompt_remaining=""; generated_eog=false : bool } })'
+    mockIC.run_test(
+        std::string(__func__) + ": " + "remove_prompt_cache " + model,
+        remove_prompt_cache,
+        "4449444c026c01dd9ad28304016d710100020e2d2d70726f6d70742d63616368650c70726f6d70742e6361636865",
+        "", silent_on_trap, my_principal);
+
+    // -----------------------------------------------------------------------------
+    // Start a new chat
     // '(record { args = vec {"--prompt-cache"; "prompt.cache"} })' ->
     // '(variant { Ok = record { status_code = 200 : nat16; output = "Ready to start a new chat for cache file .canister_cache/expmt-gtxsw-inftj-ttabj-qhp5s-nozup-n3bbo-k7zvn-dg4he-knac3-lae/sessions/prompt.cache"; input = ""; error=""; prompt_remaining=""; generated_eog=false : bool } })'
     mockIC.run_test(

--- a/native/test_tiny_stories.cpp
+++ b/native/test_tiny_stories.cpp
@@ -102,10 +102,19 @@ void test_tiny_stories(MockIC &mockIC) {
 
     // Let's have two chats with this model
     for (int i = 0; i < 2; ++i) {
+      // -----------------------------------------------------------------------------
+      // Remove the prompt-cache file if it exists
+      // '(record { args = vec {"--prompt-cache"; "prompt.cache"} })' ->
+      // '(variant { Ok = record { status_code = 200 : nat16; output = "Cache file .canister_cache/expmt-gtxsw-inftj-ttabj-qhp5s-nozup-n3bbo-k7zvn-dg4he-knac3-lae/sessions/prompt.cache deleted successfully"; input = ""; error=""; prompt_remaining=""; generated_eog=false : bool } })'
+      mockIC.run_test(
+          std::string(__func__) + ": " + "remove_prompt_cache " + model,
+          remove_prompt_cache,
+          "4449444c026c01dd9ad28304016d710100020e2d2d70726f6d70742d63616368650c70726f6d70742e6361636865",
+          "", silent_on_trap, my_principal);
       if (i == 0) {
         // -----------------------------------------------------------------------------
         // Without log file
-        // Start a new chat, which will reset the prompt-cache file
+        // Start a new chat
         // '(record { args = vec {"--prompt-cache"; "prompt.cache"} })' ->
         // '(variant { Ok = record { status_code = 200 : nat16; output = "Ready to start a new chat for cache file .canister_cache/expmt-gtxsw-inftj-ttabj-qhp5s-nozup-n3bbo-k7zvn-dg4he-knac3-lae/sessions/prompt.cache"; input = ""; error=""; prompt_remaining=""; generated_eog=false : bool } })'
         mockIC.run_test(
@@ -142,7 +151,7 @@ void test_tiny_stories(MockIC &mockIC) {
       } else {
         // -----------------------------------------------------------------------------
         // With log file
-        // Start a new chat, which will reset both the prompt-cache and log-file files
+        // Start a new chat
         // '(record { args = vec {"--log-file"; "main.log"; "--prompt-cache"; "prompt.cache"} })' ->
         // '(variant { Ok = record { status_code = 200 : nat16; output = "Ready to start a new chat for cache file .canister_cache/expmt-gtxsw-inftj-ttabj-qhp5s-nozup-n3bbo-k7zvn-dg4he-knac3-lae/sessions/prompt.cache"; input = ""; error=""; prompt_remaining=""; generated_eog=false : bool } })'
         mockIC.run_test(

--- a/native/test_tiny_stories.cpp
+++ b/native/test_tiny_stories.cpp
@@ -102,18 +102,21 @@ void test_tiny_stories(MockIC &mockIC) {
 
     // Let's have two chats with this model
     for (int i = 0; i < 2; ++i) {
-      // -----------------------------------------------------------------------------
-      // Remove the prompt-cache file if it exists
-      // '(record { args = vec {"--prompt-cache"; "prompt.cache"} })' ->
-      // '(variant { Ok = record { status_code = 200 : nat16; output = "Cache file .canister_cache/expmt-gtxsw-inftj-ttabj-qhp5s-nozup-n3bbo-k7zvn-dg4he-knac3-lae/sessions/prompt.cache deleted successfully"; input = ""; error=""; prompt_remaining=""; generated_eog=false : bool } })'
-      mockIC.run_test(
-          std::string(__func__) + ": " + "remove_prompt_cache " + model,
-          remove_prompt_cache,
-          "4449444c026c01dd9ad28304016d710100020e2d2d70726f6d70742d63616368650c70726f6d70742e6361636865",
-          "", silent_on_trap, my_principal);
+
       if (i == 0) {
+        // First chat with this model
         // -----------------------------------------------------------------------------
-        // Without log file
+        // Remove the prompt-cache file if it exists
+        // '(record { args = vec {"--prompt-cache"; "prompt.cache"} })' ->
+        // '(variant { Ok = record { status_code = 200 : nat16; output = "Cache file .canister_cache/expmt-gtxsw-inftj-ttabj-qhp5s-nozup-n3bbo-k7zvn-dg4he-knac3-lae/sessions/prompt.cache deleted successfully"; input = ""; error=""; prompt_remaining=""; generated_eog=false : bool } })'
+        mockIC.run_test(
+            std::string(__func__) + ": " + "remove_prompt_cache " + model,
+            remove_prompt_cache,
+            "4449444c026c01dd9ad28304016d710100020e2d2d70726f6d70742d63616368650c70726f6d70742e6361636865",
+            "", silent_on_trap, my_principal);
+
+        // -----------------------------------------------------------------------------
+        // Without log file & deterministic (temp=0)
         // Start a new chat
         // '(record { args = vec {"--prompt-cache"; "prompt.cache"} })' ->
         // '(variant { Ok = record { status_code = 200 : nat16; output = "Ready to start a new chat for cache file .canister_cache/expmt-gtxsw-inftj-ttabj-qhp5s-nozup-n3bbo-k7zvn-dg4he-knac3-lae/sessions/prompt.cache"; input = ""; error=""; prompt_remaining=""; generated_eog=false : bool } })'
@@ -128,30 +131,85 @@ void test_tiny_stories(MockIC &mockIC) {
         // -----------------------------------------------------------------------------
         // Generate tokens from prompt while saving everything to cache,
         // without re-reading the model !
-        // '(record { args = vec {"--prompt-cache"; "prompt.cache"; "--prompt-cache-all"; "--samplers"; "top_p"; "--temp"; "0.1"; "--top-p"; "0.9"; "-n"; "20"; "-p"; "Joe loves writing stories"} })'
+        // '(record { args = vec {"--prompt-cache"; "prompt.cache"; "--prompt-cache-all"; "--samplers"; "temperature"; "--temp"; "0.0"; "-n"; "3"; "-p"; "Joe loves writing stories"} })'
         // -> ...
+        if (model == "models/stories260Ktok512.gguf") {
+          candid_out =
+              "4449444c026c06819e846471838fe5800671c897a79907719aa1b2f90c7adb92a2c90d71cdd9e6b30e7e6b01bc8a0100010100072e204865206c691e204a6f65206c6f7665732077726974696e672073746f726965732e20486500c8000000";
+        } else {
+          candid_out =
+              "4449444c026c06819e846471838fe5800671c897a79907719aa1b2f90c7adb92a2c90d71cdd9e6b30e7e6b01bc8a0100010100082e204865206861731e204a6f65206c6f7665732077726974696e672073746f726965732e20486500c8000000";
+        }
         mockIC.run_test(
             std::string(__func__) + ": " + "run_update for chat " +
                 std::to_string(i) + " - " + model,
             run_update,
-            "4449444c026c01dd9ad28304016d7101000d0e2d2d70726f6d70742d63616368650c70726f6d70742e6361636865122d2d70726f6d70742d63616368652d616c6c0a2d2d73616d706c65727305746f705f70062d2d74656d7003302e31072d2d746f702d7003302e39022d6e023230022d70194a6f65206c6f7665732077726974696e672073746f72696573",
-            "", silent_on_trap, my_principal);
+            "4449444c026c01dd9ad28304016d7101000b0e2d2d70726f6d70742d63616368650c70726f6d70742e6361636865122d2d70726f6d70742d63616368652d616c6c0a2d2d73616d706c6572730b74656d7065726174757265062d2d74656d7003302e30022d6e0133022d70194a6f65206c6f7665732077726974696e672073746f72696573",
+            candid_out, silent_on_trap, my_principal);
 
         // -----------------------------------------------------------------------------
         // Continue generating tokens while using & saving the cache, without re-reading the model
-        // '(record { args = vec {"--prompt-cache"; "prompt.cache"; "--prompt-cache-all"; "--samplers"; "top_p"; "--temp"; "0.1"; "--top-p"; "0.9"; "-n"; "20"; "-p"; ""} })' ->
+        // '(record { args = vec {"--prompt-cache"; "prompt.cache"; "--prompt-cache-all"; "--samplers"; "temperature"; "--temp"; "0.0"; "-n"; "3"; "-p"; ""} })' ->
         // -> ...
+        if (model == "models/stories260Ktok512.gguf") {
+          candid_out =
+              "4449444c026c06819e846471838fe5800671c897a79907719aa1b2f90c7adb92a2c90d71cdd9e6b30e7e6b01bc8a010001010009206c696b656420746f24204a6f65206c6f7665732077726974696e672073746f726965732e204865206c696b656400c8000000";
+        } else {
+          candid_out =
+              "4449444c026c06819e846471838fe5800671c897a79907719aa1b2f90c7adb92a2c90d71cdd9e6b30e7e6b01bc8a01000101000e206861732061207370656369616c24204a6f65206c6f7665732077726974696e672073746f726965732e20486520686173206100c8000000";
+        }
         mockIC.run_test(
             std::string(__func__) + ": " + "run_update for chat " +
                 std::to_string(i) + " continued - " + model,
             run_update,
-            "4449444c026c01dd9ad28304016d7101000d0e2d2d70726f6d70742d63616368650c70726f6d70742e6361636865122d2d70726f6d70742d63616368652d616c6c0a2d2d73616d706c65727305746f705f70062d2d74656d7003302e31072d2d746f702d7003302e39022d6e023230022d7000",
-            "", silent_on_trap, my_principal);
+            "4449444c026c01dd9ad28304016d7101000b0e2d2d70726f6d70742d63616368650c70726f6d70742e6361636865122d2d70726f6d70742d63616368652d616c6c0a2d2d73616d706c6572730b74656d7065726174757265062d2d74656d7003302e30022d6e0133022d7000",
+            candid_out, silent_on_trap, my_principal);
 
       } else {
+        // Second chat with this model
+        // -----------------------------------------------------------------------------
+        // copy "prompt.cache" file to "prompt-save.cache"
+        // '(record { from = "prompt.cache"; to = "prompt-save.cache" })' ->
+        // '(variant { Ok = record { status_code = 200 : nat16; } })'
+        mockIC.run_test(
+            std::string(__func__) + ": " + "copy_prompt_cache " + model,
+            copy_prompt_cache,
+            "4449444c016c02fbca0171eaca8a9e047101001170726f6d70742d736176652e63616368650c70726f6d70742e6361636865",
+            "4449444c026c019aa1b2f90c7a6b01bc8a0100010100c800", silent_on_trap,
+            my_principal);
+        // -----------------------------------------------------------------------------
+        // Remove "prompt.cache" file
+        // '(record { args = vec {"--prompt-cache"; "prompt.cache"} })' ->
+        // '(variant { Ok = record { status_code = 200 : nat16; output = "Cache file .canister_cache/expmt-gtxsw-inftj-ttabj-qhp5s-nozup-n3bbo-k7zvn-dg4he-knac3-lae/sessions/prompt.cache deleted successfully"; input = ""; error=""; prompt_remaining=""; generated_eog=false : bool } })'
+        mockIC.run_test(
+            std::string(__func__) + ": " + "remove_prompt_cache " + model,
+            remove_prompt_cache,
+            "4449444c026c01dd9ad28304016d710100020e2d2d70726f6d70742d63616368650c70726f6d70742e6361636865",
+            "4449444c026c06819e846471838fe5800671c897a79907719aa1b2f90c7adb92a2c90d71cdd9e6b30e7e6b01bc8a0100010100850143616368652066696c65202e63616e69737465725f63616368652f6578706d742d67747873772d696e66746a2d747461626a2d71687035732d6e6f7a75702d6e3362626f2d6b377a766e2d64673468652d6b6e6163332d6c61652f73657373696f6e732f70726f6d70742e63616368652064656c65746564207375636365737366756c6c790000c8000000",
+            silent_on_trap, my_principal);
+        // -----------------------------------------------------------------------------
+        // copy "prompt-save.cache" file back to "prompt.cache"
+        // '(record { from = "prompt-save.cache"; to = "prompt.cache" })' ->
+        // '(variant { Ok = record { status_code = 200 : nat16; } })'
+        mockIC.run_test(
+            std::string(__func__) + ": " + "copy_prompt_cache restore" + model,
+            copy_prompt_cache,
+            "4449444c016c02fbca0171eaca8a9e047101000c70726f6d70742e63616368651170726f6d70742d736176652e6361636865",
+            "4449444c026c019aa1b2f90c7a6b01bc8a0100010100c800", silent_on_trap,
+            my_principal);
+        // -----------------------------------------------------------------------------
+        // Remove "prompt-save.cache" file
+        // '(record { args = vec {"--prompt-cache"; "prompt-save.cache"} })' ->
+        // '(variant { Ok = record { status_code = 200 : nat16; output = "Cache file .canister_cache/expmt-gtxsw-inftj-ttabj-qhp5s-nozup-n3bbo-k7zvn-dg4he-knac3-lae/sessions/prompt-save.cache deleted successfully"; input = ""; error=""; prompt_remaining=""; generated_eog=false : bool } })'
+        mockIC.run_test(
+            std::string(__func__) + ": " +
+                "remove_prompt_cache prompt-save.cache " + model,
+            remove_prompt_cache,
+            "4449444c026c01dd9ad28304016d710100020e2d2d70726f6d70742d63616368651170726f6d70742d736176652e6361636865",
+            "", silent_on_trap, my_principal);
         // -----------------------------------------------------------------------------
         // With log file
-        // Start a new chat
+        // Start a new chat, re-using the cache
         // '(record { args = vec {"--log-file"; "main.log"; "--prompt-cache"; "prompt.cache"} })' ->
         // '(variant { Ok = record { status_code = 200 : nat16; output = "Ready to start a new chat for cache file .canister_cache/expmt-gtxsw-inftj-ttabj-qhp5s-nozup-n3bbo-k7zvn-dg4he-knac3-lae/sessions/prompt.cache"; input = ""; error=""; prompt_remaining=""; generated_eog=false : bool } })'
         mockIC.run_test(
@@ -165,49 +223,63 @@ void test_tiny_stories(MockIC &mockIC) {
         // -----------------------------------------------------------------------------
         // Generate tokens from prompt while saving everything to cache,
         // without re-reading the model !
-        // '(record { args = vec {"--log-file"; "main.log"; "--prompt-cache"; "prompt.cache"; "--prompt-cache-all"; "--samplers"; "top_p"; "--temp"; "0.1"; "--top-p"; "0.9"; "-n"; "20"; "-p"; "Joe loves writing stories"} })'
+        // '(record { args = vec {"--log-file"; "main.log"; "--prompt-cache"; "prompt.cache"; "--prompt-cache-all"; "--samplers"; "temperature"; "--temp"; "0.0"; "-n"; "3"; "-p"; "Joe loves writing stories"} })'
         // -> ...
+        if (model == "models/stories260Ktok512.gguf") {
+          candid_out =
+              "4449444c026c06819e846471838fe5800671c897a79907719aa1b2f90c7adb92a2c90d71cdd9e6b30e7e6b01bc8a0100010100072e204865206c691e204a6f65206c6f7665732077726974696e672073746f726965732e20486500c8000000";
+        } else {
+          candid_out =
+              "4449444c026c06819e846471838fe5800671c897a79907719aa1b2f90c7adb92a2c90d71cdd9e6b30e7e6b01bc8a0100010100082e204865206861731e204a6f65206c6f7665732077726974696e672073746f726965732e20486500c8000000";
+        }
         mockIC.run_test(
             std::string(__func__) + ": " + "run_update for chat " +
                 std::to_string(i) + " - " + model,
             run_update,
-            "4449444c026c01dd9ad28304016d7101000f0a2d2d6c6f672d66696c65086d61696e2e6c6f670e2d2d70726f6d70742d63616368650c70726f6d70742e6361636865122d2d70726f6d70742d63616368652d616c6c0a2d2d73616d706c65727305746f705f70062d2d74656d7003302e31072d2d746f702d7003302e39022d6e023230022d70194a6f65206c6f7665732077726974696e672073746f72696573",
-            "", silent_on_trap, my_principal);
+            "4449444c026c01dd9ad28304016d7101000d0a2d2d6c6f672d66696c65086d61696e2e6c6f670e2d2d70726f6d70742d63616368650c70726f6d70742e6361636865122d2d70726f6d70742d63616368652d616c6c0a2d2d73616d706c6572730b74656d7065726174757265062d2d74656d7003302e30022d6e0133022d70194a6f65206c6f7665732077726974696e672073746f72696573",
+            candid_out, silent_on_trap, my_principal);
 
         // -----------------------------------------------------------------------------
         // Continue generating tokens while using & saving the cache, without re-reading the model
-        // '(record { args = vec {"--log-file"; "main.log"; "--prompt-cache"; "prompt.cache"; "--prompt-cache-all"; "--samplers"; "top_p"; "--temp"; "0.1"; "--top-p"; "0.9"; "-n"; "20"; "-p"; ""} })' ->
+        // '(record { args = vec {"--log-file"; "main.log"; "--prompt-cache"; "prompt.cache"; "--prompt-cache-all"; "--samplers"; "temperature"; "--temp"; "0.0"; "-n"; "3"; "-p"; ""} })' ->
         // -> ...
+        if (model == "models/stories260Ktok512.gguf") {
+          candid_out =
+              "4449444c026c06819e846471838fe5800671c897a79907719aa1b2f90c7adb92a2c90d71cdd9e6b30e7e6b01bc8a010001010008206c69766564206124204a6f65206c6f7665732077726974696e672073746f726965732e204865206c6976656400c8000000";
+        } else {
+          candid_out =
+              "4449444c026c06819e846471838fe5800671c897a79907719aa1b2f90c7adb92a2c90d71cdd9e6b30e7e6b01bc8a01000101000e206861732061207370656369616c24204a6f65206c6f7665732077726974696e672073746f726965732e20486520686173206100c8000000";
+        }
         mockIC.run_test(
             std::string(__func__) + ": " + "run_update for chat " +
                 std::to_string(i) + " continued - " + model,
             run_update,
-            "4449444c026c01dd9ad28304016d7101000f0a2d2d6c6f672d66696c65086d61696e2e6c6f670e2d2d70726f6d70742d63616368650c70726f6d70742e6361636865122d2d70726f6d70742d63616368652d616c6c0a2d2d73616d706c65727305746f705f70062d2d74656d7003302e31072d2d746f702d7003302e39022d6e023230022d7000",
-            "", silent_on_trap, my_principal);
+            "4449444c026c01dd9ad28304016d7101000d0a2d2d6c6f672d66696c65086d61696e2e6c6f670e2d2d70726f6d70742d63616368650c70726f6d70742e6361636865122d2d70726f6d70742d63616368652d616c6c0a2d2d73616d706c6572730b74656d7065726174757265062d2d74656d7003302e30022d6e0133022d7000",
+            candid_out, silent_on_trap, my_principal);
+
+        // -----------------------------------------------------------------------------
+        // Remove the prompt-cache files
+        // '(record { args = vec {"--prompt-cache"; "prompt.cache"} })' ->
+        // '(variant { Ok = record { status_code = 200 : nat16; output = "Cache file .canister_cache/expmt-gtxsw-inftj-ttabj-qhp5s-nozup-n3bbo-k7zvn-dg4he-knac3-lae/sessions/prompt.cache deleted successfully"; input = ""; error=""; prompt_remaining=""; generated_eog=false : bool } })'
+        mockIC.run_test(
+            std::string(__func__) + ": " + "remove_prompt_cache " +
+                std::to_string(i) + " - " + model,
+            remove_prompt_cache,
+            "4449444c026c01dd9ad28304016d710100020e2d2d70726f6d70742d63616368650c70726f6d70742e6361636865",
+            "4449444c026c06819e846471838fe5800671c897a79907719aa1b2f90c7adb92a2c90d71cdd9e6b30e7e6b01bc8a0100010100850143616368652066696c65202e63616e69737465725f63616368652f6578706d742d67747873772d696e66746a2d747461626a2d71687035732d6e6f7a75702d6e3362626f2d6b377a766e2d64673468652d6b6e6163332d6c61652f73657373696f6e732f70726f6d70742e63616368652064656c65746564207375636365737366756c6c790000c8000000",
+            silent_on_trap, my_principal);
+
+        // -----------------------------------------------------------------------------
+        // Remove the log-file file if it exists
+        // '(record { args = vec {"--log-file"; "main.log"} })' ->
+        // '(variant { Ok = record { status_code = 200 : nat16; output = "Successfully removed log file: main.log"; input = ""; error=""; prompt_remaining=""; generated_eog=false : bool } })'
+        mockIC.run_test(
+            std::string(__func__) + ": " + "remove_log_file " + model,
+            remove_log_file,
+            "4449444c026c01dd9ad28304016d710100020a2d2d6c6f672d66696c65086d61696e2e6c6f67",
+            "4449444c026c06819e846471838fe5800671c897a79907719aa1b2f90c7adb92a2c90d71cdd9e6b30e7e6b01bc8a0100010100275375636365737366756c6c792072656d6f766564206c6f672066696c653a206d61696e2e6c6f670000c8000000",
+            silent_on_trap, my_principal);
       }
-
-      // -----------------------------------------------------------------------------
-      // Remove the prompt-cache file if it exists
-      // '(record { args = vec {"--prompt-cache"; "prompt.cache"} })' ->
-      // '(variant { Ok = record { status_code = 200 : nat16; output = "Cache file .canister_cache/expmt-gtxsw-inftj-ttabj-qhp5s-nozup-n3bbo-k7zvn-dg4he-knac3-lae/sessions/prompt.cache deleted successfully"; input = ""; error=""; prompt_remaining=""; generated_eog=false : bool } })'
-      mockIC.run_test(
-          std::string(__func__) + ": " + "remove_prompt_cache " +
-              std::to_string(i) + " - " + model,
-          remove_prompt_cache,
-          "4449444c026c01dd9ad28304016d710100020e2d2d70726f6d70742d63616368650c70726f6d70742e6361636865",
-          "4449444c026c06819e846471838fe5800671c897a79907719aa1b2f90c7adb92a2c90d71cdd9e6b30e7e6b01bc8a0100010100850143616368652066696c65202e63616e69737465725f63616368652f6578706d742d67747873772d696e66746a2d747461626a2d71687035732d6e6f7a75702d6e3362626f2d6b377a766e2d64673468652d6b6e6163332d6c61652f73657373696f6e732f70726f6d70742e63616368652064656c65746564207375636365737366756c6c790000c8000000",
-          silent_on_trap, my_principal);
-
-      // -----------------------------------------------------------------------------
-      // Remove the log-file file if it exists
-      // '(record { args = vec {"--log-file"; "main.log"} })' ->
-      // '(variant { Ok = record { status_code = 200 : nat16; output = "Successfully removed log file: main.log"; input = ""; error=""; prompt_remaining=""; generated_eog=false : bool } })'
-      mockIC.run_test(
-          std::string(__func__) + ": " + "remove_log_file " + model,
-          remove_log_file,
-          "4449444c026c01dd9ad28304016d710100020a2d2d6c6f672d66696c65086d61696e2e6c6f67",
-          "4449444c026c06819e846471838fe5800671c897a79907719aa1b2f90c7adb92a2c90d71cdd9e6b30e7e6b01bc8a0100010100275375636365737366756c6c792072656d6f766564206c6f672066696c653a206d61696e2e6c6f670000c8000000",
-          silent_on_trap, my_principal);
     }
   }
 

--- a/scripts/prompt-design.ipynb
+++ b/scripts/prompt-design.ipynb
@@ -158,7 +158,6 @@
     "# LLAMA_CLI_PATH = \"../../ggerganov_llama_b841d0.cpp/llama-cli\" # Current llama_cpp_canister version\n",
     "\n",
     "\n",
-    "\n",
     "# ####################################################################### #\n",
     "# Define the MODEL_TYPE and MODEL (location is relative to this notebook) #\n",
     "# ####################################################################### #\n",

--- a/scripts/qa_deploy_and_pytest.py
+++ b/scripts/qa_deploy_and_pytest.py
@@ -23,7 +23,7 @@ def main() -> int:
         tests = [
             {
                 "filename": "models/stories260Ktok512.gguf",
-                "canister_filename": "models/model.gguf",
+                "canister_filename": "models/tiny.gguf",
                 "test_path_model": "test/test_tiny_stories.py",
             },
             # This times out in Github action. Can only be run locally.

--- a/src/llama_cpp.did
+++ b/src/llama_cpp.did
@@ -84,6 +84,12 @@ type GetChatsRecord = record {
 };
 
 // -----------------------------------------------------
+type CopyPromptCacheInputRecord = record {
+  from : text;
+  to : text;
+};
+
+// -----------------------------------------------------
 // Access level
 // 0 = only controllers
 // 1 = all except anonymous
@@ -120,6 +126,7 @@ service : {
   run_query : (InputRecord) -> (OutputRecordResult) query;
   run_update : (InputRecord) -> (OutputRecordResult);
   remove_prompt_cache : (InputRecord) -> (OutputRecordResult);
+  copy_prompt_cache : (CopyPromptCacheInputRecord) -> (StatusCodeRecordResult);
 
   // Logging endpoints
   remove_log_file : (InputRecord) -> (OutputRecordResult);

--- a/src/run.cpp
+++ b/src/run.cpp
@@ -73,7 +73,6 @@ void new_chat() {
   }
 
   // -----------------------------------------------------------
-  // Create/reset a prompt-cache file to zero length, will reset the LLM state for that conversation
   // Each principal has their own cache folder
   std::string path_session = params.path_prompt_cache;
   std::string canister_path_session;
@@ -89,18 +88,9 @@ void new_chat() {
   if (!path_session.empty()) {
 
     if (std::filesystem::exists(path_session)) {
-      // First, remove the file if it exists
-      bool success = std::filesystem::remove(path_session);
-      if (success) {
-        msg = "Cache file " + path_session + " deleted successfully";
-      } else {
-        error_msg = "Error deleting cache file " + path_session;
-        send_output_record_result_error_to_wire(
-            ic_api, Http::StatusCode::InternalServerError, error_msg);
-        return;
-      }
+      msg = "Re-using existing prompt-cache file " + path_session;
     } else {
-      msg = "Cache file " + path_session + " not found. Nothing to delete.";
+      msg = "Will create new prompt-cache file " + path_session;
     }
   } else {
     error_msg = "ERROR: path_session is empty ";
@@ -108,7 +98,7 @@ void new_chat() {
         ic_api, Http::StatusCode::InternalServerError, error_msg);
     return;
   }
-  // std::cout << msg << std::endl;
+  std::cout << msg << std::endl;
 
   // Simpler message back to the wire
   msg = "Ready to start a new chat for cache file " + path_session;

--- a/src/run.h
+++ b/src/run.h
@@ -8,6 +8,8 @@ void run_query() WASM_SYMBOL_EXPORTED("canister_query run_query");
 void run_update() WASM_SYMBOL_EXPORTED("canister_update run_update");
 void remove_prompt_cache()
     WASM_SYMBOL_EXPORTED("canister_update remove_prompt_cache");
+void copy_prompt_cache()
+    WASM_SYMBOL_EXPORTED("canister_update copy_prompt_cache");
 
 bool get_canister_path_session(const std::string &path_session,
                                const std::string &principal_id,

--- a/test/test_qwen2.py
+++ b/test/test_qwen2.py
@@ -71,6 +71,16 @@ def test__ready(network: str) -> None:
     expected_response = '(variant { Ok = record { status_code = 200 : nat16;} })'
     assert response == expected_response
 
+def test__remove_prompt_cache(network: str) -> None:
+    response = call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="remove_prompt_cache",
+        canister_argument='(record { args = vec {"--prompt-cache"; "prompt.cache"} })',
+        network=network,
+    )
+    assert "(variant { Ok" in response
+
 def test__new_chat(network: str) -> None:
     response = call_canister_api(
         dfx_json_path=DFX_JSON_PATH,
@@ -91,6 +101,16 @@ def test__run_update_1(network: str) -> None:
     )
     expected_response = '(variant { Ok = record { output = ""; conversation = "<|im_start|>system\\nYou are a helpful assistant.<|im_end|>"; error = ""; status_code = 200 : nat16; prompt_remaining = "\\n<|im_start|>user\\nExplain Large Language Models.<|im_end|>\\n<|im_start|>assistant\\n"; generated_eog = false;} })'
     assert expected_response == response
+
+def test__copy_prompt_cache_save(network: str) -> None:
+    response = call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="copy_prompt_cache",
+        canister_argument='(record { from = "prompt.cache"; to = "prompt-save.cache"} )',
+        network=network,
+    )
+    assert "(variant { Ok" in response
 
 def test__run_update_2(network: str) -> None:
     response = call_canister_api(
@@ -130,6 +150,56 @@ def test__remove_prompt_cache(network: str) -> None:
         canister_name=CANISTER_NAME,
         canister_method="remove_prompt_cache",
         canister_argument='(record { args = vec {"--prompt-cache"; "prompt.cache"} })',
+        network=network,
+    )
+    assert "(variant { Ok" in response
+
+def test__copy_prompt_cache_restore(network: str) -> None:
+    response = call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="copy_prompt_cache",
+        canister_argument='(record { from = "prompt-save.cache"; to = "prompt.cache"} )',
+        network=network,
+    )
+    assert "(variant { Ok" in response
+
+def test__new_chat(network: str) -> None:
+    response = call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="new_chat",
+        canister_argument='(record { args = vec {"--prompt-cache"; "prompt.cache"} })',
+        network=network,
+    )
+    assert "(variant { Ok" in response
+
+def test__run_update_2_2(network: str) -> None:
+    response = call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="run_update",
+        canister_argument='(record { args = vec {"--prompt-cache"; "prompt.cache"; "--prompt-cache-all"; "-sp"; "-n"; "512"; "-p"; "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nExplain Large Language Models.<|im_end|>\n<|im_start|>assistant\n"} })',
+        network=network,
+    )
+    expected_response = '(variant { Ok = record { output = ""; conversation = "<|im_start|>system\\nYou are a helpful assistant.<|im_end|>\\n<|im_start|>user\\nExplain Large Language Models."; error = ""; status_code = 200 : nat16; prompt_remaining = "<|im_end|>\\n<|im_start|>assistant\\n"; generated_eog = false;} })'
+    assert expected_response == response
+
+def test__remove_prompt_cache_cleanup(network: str) -> None:
+    response = call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="remove_prompt_cache",
+        canister_argument='(record { args = vec {"--prompt-cache"; "prompt.cache"} })',
+        network=network,
+    )
+    assert "(variant { Ok" in response
+
+    response = call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="remove_prompt_cache",
+        canister_argument='(record { args = vec {"--prompt-cache"; "prompt-save.cache"} })',
         network=network,
     )
     assert "(variant { Ok" in response

--- a/test/test_qwen2.py
+++ b/test/test_qwen2.py
@@ -71,7 +71,7 @@ def test__ready(network: str) -> None:
     expected_response = '(variant { Ok = record { status_code = 200 : nat16;} })'
     assert response == expected_response
 
-def test__remove_prompt_cache(network: str) -> None:
+def test__remove_prompt_cache_1(network: str) -> None:
     response = call_canister_api(
         dfx_json_path=DFX_JSON_PATH,
         canister_name=CANISTER_NAME,
@@ -81,7 +81,7 @@ def test__remove_prompt_cache(network: str) -> None:
     )
     assert "(variant { Ok" in response
 
-def test__new_chat(network: str) -> None:
+def test__new_chat_1(network: str) -> None:
     response = call_canister_api(
         dfx_json_path=DFX_JSON_PATH,
         canister_name=CANISTER_NAME,
@@ -144,7 +144,7 @@ def test__run_update_4(network: str) -> None:
     expected_response = '(variant { Ok = record { status_code = 200 : nat16; error = ""; output = ""; input = "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>" ; prompt_remaining = "user\nExplain Large Language Models.<|im_end|>\n<|im_start|>assistant\n"; generated_eog=false : bool} })'
     assert "(variant { Ok" in response
 
-def test__remove_prompt_cache(network: str) -> None:
+def test__remove_prompt_cache_2(network: str) -> None:
     response = call_canister_api(
         dfx_json_path=DFX_JSON_PATH,
         canister_name=CANISTER_NAME,
@@ -164,7 +164,7 @@ def test__copy_prompt_cache_restore(network: str) -> None:
     )
     assert "(variant { Ok" in response
 
-def test__new_chat(network: str) -> None:
+def test__new_chat_2(network: str) -> None:
     response = call_canister_api(
         dfx_json_path=DFX_JSON_PATH,
         canister_name=CANISTER_NAME,


### PR DESCRIPTION
# Prompt Caching

When a prompt cache file is already present, llama_cpp_canister automatically applies prompt caching to reduce latency and cost.

All repetitive content at the beginning of the prompt does not need to be processed by the LLM, so make sure to design your AI agent prompts such that repetitive content is placed at the beginning.

Each caller of the llama_cpp_canister has it's own cache folder, and has the following endpoints available to manage their prompt-cache files:

```bash
# Remove a prompt cache file from the caller's cache folder
dfx canister call llama_cpp remove_prompt_cache '(record { args = vec {"--prompt-cache"; "prompt.cache"} })'

# Copy a prompt cache file within the caller's cache folder
dfx canister call llama_cpp copy_prompt_cache '(record { from = "prompt.cache"; to = "prompt-save.cache"} )'
```