### PR TITLE
Make upload of file-chunks idempotent to correctly handle timeouts

### DIFF
--- a/scripts/parse_args_upload.py
+++ b/scripts/parse_args_upload.py
@@ -45,7 +45,7 @@ def parse_args() -> argparse.Namespace:
         "--chunksize",
         type=int,
         default=2000000,
-        help="Chunk Size used during file download, in bytes",
+        help="Chunk Size used during file upload, in bytes",
     )
     parser.add_argument(
         "--hf-sha256",

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -24,7 +24,7 @@ ROOT_PATH = Path(__file__).parent.parent
 #  0 - none
 #  1 - minimal
 #  2 - a lot
-DEBUG_VERBOSE = 1
+DEBUG_VERBOSE = 2
 
 
 def read_file_bytes(file_path: Path) -> bytes:
@@ -142,7 +142,7 @@ def main() -> int:
             print("+++++++++++++++++++++++++++++++++++++++++++++++++++++")
             print(f"Sending another chunk for {len(chunk)} bytes :")
             print(f"- i         = {i}")
-            print(f"- progress  = {offset+len(chunk) / len(file_bytes) * 100:.1f} % ")
+            print(f"- progress  = {(offset+len(chunk)) / len(file_bytes) * 100:.1f} % ")
             print(f"- chunk[0]  = {chunk[0]}")
             print(f"- chunk[-1] = {chunk[-1]}")
 


### PR DESCRIPTION
The uploading of a file chunk to these canisters was not 'idempotent'. 

What sometimes (rarely) happens is the following:

- The Python upload script sends a file chunk
- The chunk arrives at the canister endpoint
- The canister handles it correctly and saves the file chunk in stable storage
- BUT... before the canister is done, the IC throws a timeout
- The python upload script receives a timeout error, and simply re-sends the same chunk
- The canister now adds the bytes of that file chunk twice

The updates of this PR make the endpoint idempotent, so it is OK for an upload client to send the same chunk twice.