### PR TITLE
Add prompt-cache cleanup timer (icpp-pro 5.4.1)

### DIFF
--- a/.github/workflows/cicd-mac.yml
+++ b/.github/workflows/cicd-mac.yml
@@ -9,6 +9,7 @@ on:
       - "src/**"
       - "test/**"
       - "Makefile"
+      - "requirements.txt"
       - ".github/trigger.txt"
       - ".github/workflows/cicd-mac.yml"
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -79,92 +79,36 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        long-suffix,
-        old-ne-operator,
-        old-octal-literal,
-        import-star-module-level,
-        non-ascii-bytes-literal,
-        raw-checker-failed,
+disable=raw-checker-failed,
         bad-inline-option,
         locally-disabled,
-        locally-enabled,
         file-ignored,
         suppressed-message,
         useless-suppression,
         deprecated-pragma,
         use-symbolic-message-instead,
-        apply-builtin,
-        basestring-builtin,
-        buffer-builtin,
-        cmp-builtin,
-        coerce-builtin,
-        execfile-builtin,
-        file-builtin,
-        long-builtin,
-        raw_input-builtin,
-        reduce-builtin,
-        standarderror-builtin,
-        unicode-builtin,
-        xrange-builtin,
-        coerce-method,
-        delslice-method,
-        getslice-method,
-        setslice-method,
-        no-absolute-import,
-        old-division,
-        dict-iter-method,
-        dict-view-method,
-        next-method-called,
-        metaclass-assignment,
-        indexing-exception,
-        raising-string,
-        reload-builtin,
-        oct-method,
-        hex-method,
-        nonzero-method,
-        cmp-method,
-        input-builtin,
-        round-builtin,
-        intern-builtin,
-        unichr-builtin,
-        map-builtin-not-iterating,
-        zip-builtin-not-iterating,
-        range-builtin-not-iterating,
-        filter-builtin-not-iterating,
-        using-cmp-argument,
-        eq-without-hash,
-        div-method,
-        idiv-method,
-        rdiv-method,
-        exception-message-attribute,
-        invalid-str-codec,
-        sys-max-int,
-        bad-python3-import,
-        deprecated-string-function,
-        deprecated-str-translate-call,
-        deprecated-itertools-function,
-        deprecated-types-field,
-        next-method-defined,
-        dict-items-not-iterating,
-        dict-keys-not-iterating,
-        dict-values-not-iterating,
-        deprecated-operator-function,
-        deprecated-urllib-function,
-        xreadlines-attribute,
-        deprecated-sys-function,
-        exception-escape,
-        comprehension-escape,
-        bare-except, too-many-arguments, too-many-instance-attributes,
-        too-many-branches, too-many-locals, 
-        bad-continuation, bad-whitespace,
+        bare-except,
+        too-many-arguments,
+        too-many-positional-arguments,
+        too-many-instance-attributes,
+        too-many-branches,
+        too-many-locals,
+        too-many-statements,
         logging-fstring-interpolation,
-        duplicate-code, fixme
-#ICPP: I started adding with 'bare-except'
+        duplicate-code,
+        fixme,
+        cyclic-import
+# Notes:
+#  - The earlier disable list contained dozens of Python-2-to-3 transition
+#    checks (e.g. print-statement, basestring-builtin, dict-iter-method).
+#    Those checkers were removed in pylint 3.x; leaving them in the disable
+#    list produces useless-option-value warnings.
+#  - 'cyclic-import' is disabled because the icpp.__main__ → commands_*
+#    → decorators chain forms a cycle that pylint 3.x detects more
+#    aggressively than 2.x; refactoring it is out of scope for the lint
+#    bump that ships with the Python 3.10–3.14 matrix update.
+#  - The 'no-space-check' option was removed by pylint 3.x as well; it
+#    was elsewhere in this file and has been deleted.
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -473,12 +417,9 @@ max-line-length=89
 # Maximum number of lines in a module.
 max-module-lines=2000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
+# Note: the 'no-space-check' option (which used to live here, configuring
+# `trailing-comma` and `dict-separator`) was removed in pylint 3.x because
+# whitespace checks themselves were dropped in favor of black formatting.
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
@@ -582,4 +523,4 @@ min-public-methods=2
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception".
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/README.md
+++ b/README.md
@@ -642,6 +642,73 @@ dfx canister call llama_cpp get_creation_timestamp_ns '(record {filename = "<fil
 dfx canister call llama_cpp filesystem_remove '(record {filename = "<filename>"})'
 ```
 
+# Prompt-Cache Cleanup Timer
+
+The canister can self-maintain its prompt-cache directory on a recurring
+schedule, deleting files in `.canister_cache/<principal>/sessions/` whose
+`mtime` is older than a configurable Time to Live (TTL). Once you start the
+timer, the canister handles prompt-cache hygiene on its own.
+
+**Defaults:**
+- period: 600 seconds (10 minutes between cleanup ticks)
+- TTL: 21600 seconds (6 hours — older files are deleted)
+- per-tick cap: 256 files (caps work-per-tick to stay under the IC's
+  per-message instruction budget; the next tick continues)
+
+**Operator-driven lifecycle.** The timer is **not** auto-armed in
+`canister_init` or `canister_post_upgrade`. After every install / upgrade
+you must explicitly call `cache_cleanup_start_timer`. Timer state is
+in-memory only and does not survive an upgrade.
+
+All endpoints below require **admin role**:
+- `cache_cleanup_start_timer`, `cache_cleanup_stop_timer`,
+  `cache_cleanup_now`, `set_cache_cleanup_config` need `AdminUpdate` role
+  (controller or whitelisted via `assignAdminRole`).
+- `get_cache_cleanup_stats` needs `AdminQuery` role.
+
+```bash
+# ------------------------------------------------------------------
+# Arm the recurring timer (REQUIRED after every install / upgrade)
+dfx canister call llama_cpp cache_cleanup_start_timer '()'
+# -> (variant { Ok = record { ok = true; is_running = true } })
+
+# Stop the recurring timer
+dfx canister call llama_cpp cache_cleanup_stop_timer '()'
+# -> (variant { Ok = record { ok = true; is_running = false } })
+
+# Trigger one cleanup pass immediately (independent of the timer state)
+dfx canister call llama_cpp cache_cleanup_now '()'
+# -> (variant { Ok = record { runs = ...; files_examined = ...;
+#                             files_deleted = ...; files_failed = ...;
+#                             last_run_ns = ...; period_seconds = 600;
+#                             ttl_seconds = 21_600;
+#                             max_files_per_run = 256;
+#                             is_running = ... } })
+
+# Inspect stats (query, fast). `runs` and `last_run_ns` are lifetime
+# counters; `files_examined`, `files_deleted`, `files_failed` reflect the
+# MOST RECENT cleanup run only.
+dfx canister call llama_cpp get_cache_cleanup_stats '()'
+
+# Adjust config (each field is `opt nat64`; null = no change).
+#   - period_seconds: must be > 0; opt 0 is silently rejected.
+#   - ttl_seconds   : 0 is valid ("delete every file under sessions/").
+#   - max_files_per_run: clamped to [1, 10000].
+# If the timer is already running, the new period is applied transparently.
+dfx canister call llama_cpp set_cache_cleanup_config '(record {
+  period_seconds    = opt (300 : nat64);
+  ttl_seconds       = opt (3600 : nat64);
+  max_files_per_run = opt (128 : nat64)
+})'
+
+# Same call to update only the TTL, leaving period and cap unchanged
+dfx canister call llama_cpp set_cache_cleanup_config '(record {
+  period_seconds    = null;
+  ttl_seconds       = opt (3600 : nat64);
+  max_files_per_run = null
+})'
+```
+
 # Wasm Verification (pre onicai SNS)
 
 > **NOTE:** This workflow was created for the **pre onicai SNS verification

--- a/native/main.cpp
+++ b/native/main.cpp
@@ -3,6 +3,7 @@
 
 #include "main.h"
 #include "test_admin_rbac.h"
+#include "test_cache_cleanup.h"
 #include "test_canister_functions.h"
 #include "test_files.h"
 #include "test_qwen2.h"
@@ -28,6 +29,7 @@ int main() {
   MockIC mockIC(exit_on_fail);
 
   test_admin_rbac(mockIC);
+  test_cache_cleanup(mockIC);
   test_canister_functions(mockIC);
   test_files(mockIC);
   test_tiny_stories(mockIC);

--- a/native/test_cache_cleanup.cpp
+++ b/native/test_cache_cleanup.cpp
@@ -1,0 +1,419 @@
+// Native tests for the recurring prompt-cache cleanup timer.
+//
+// Strategy:
+//   - Test the cleanup body by direct call to run_cache_cleanup_body() so we
+//     bypass the candid encode/decode boundary; assertions read the extern
+//     counters in cache_cleanup.h directly. `runs` is lifetime-monotonic so
+//     we delta-check it; `files_examined`/`files_deleted`/`files_failed` are
+//     last-run only so we assert absolute values.
+//   - Test the start/stop endpoints via mockIC.run_test, verifying timer
+//     registry size via IcTimers::instance().size().
+//   - Test access-denied responses via mockIC.run_test with the anonymous
+//     principal; output candid matches the project's ACCESS_DENIED_API_ERROR.
+//
+// Each scenario sets up its own files under
+// `.canister_cache/cache_cleanup_test_principal/...` (a fixed unique path so
+// other tests do not collide) and tears them down at the end. File mtimes
+// are set with std::filesystem::last_write_time using file_clock::now() —
+// NOT ic0mock_set_time_override — because cleanup compares ages in the host
+// file_clock domain.
+
+#include "test_cache_cleanup.h"
+
+#include "../src/cache_cleanup.h"
+#include "../src/upload.h"
+
+#include "ic_timers.h"
+#include "mock_ic.h"
+
+// Mock-only helpers for pinning IC_API::time() so the timer-fires test
+// is deterministic (the cleanup body itself uses host file_clock for age
+// math; ic0mock_set_time_override only affects IC_API::time(), which
+// drives IcTimers's deadline scheduling).
+#include "ic0.h"
+
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+constexpr const char *TEST_PRINCIPAL_DIR = "cache_cleanup_test_principal";
+
+// Path helper: .canister_cache/<test_principal>/sessions/<filename>
+std::filesystem::path session_path(const std::string &filename) {
+  return std::filesystem::path(".canister_cache") / TEST_PRINCIPAL_DIR /
+         "sessions" / filename;
+}
+
+// Path helper: .canister_cache/<test_principal>/db_chats/<filename>
+std::filesystem::path db_chats_path(const std::string &filename) {
+  return std::filesystem::path(".canister_cache") / TEST_PRINCIPAL_DIR /
+         "db_chats" / filename;
+}
+
+// Create an empty file at `path`, then set its mtime to `mtime`.
+bool create_test_file(const std::filesystem::path &path,
+                      std::chrono::file_clock::time_point mtime) {
+  std::error_code ec;
+  std::filesystem::create_directories(path.parent_path(), ec);
+  if (ec) {
+    std::cerr << "create_directories failed for " << path.parent_path() << ": "
+              << ec.message() << '\n';
+    return false;
+  }
+  std::ofstream(path).close();
+  std::filesystem::last_write_time(path, mtime, ec);
+  if (ec) {
+    std::cerr << "last_write_time failed for " << path << ": " << ec.message()
+              << '\n';
+    return false;
+  }
+  return true;
+}
+
+// Wipe the test_principal dir between scenarios so each starts clean.
+void clear_test_dir() {
+  std::error_code ec;
+  std::filesystem::remove_all(
+      std::filesystem::path(".canister_cache") / TEST_PRINCIPAL_DIR, ec);
+}
+
+int expect_eq_u64(const char *label, uint64_t actual, uint64_t expected) {
+  if (actual != expected) {
+    std::cout << "FAIL: " << label << " expected " << expected << ", got "
+              << actual << '\n';
+    return 1;
+  }
+  std::cout << "PASS: " << label << " == " << actual << '\n';
+  return 0;
+}
+
+int expect_file_exists(const char *label, const std::filesystem::path &p,
+                       bool expected) {
+  std::error_code ec;
+  bool actual = std::filesystem::exists(p, ec);
+  if (actual != expected) {
+    std::cout << "FAIL: " << label << " expected exists=" << expected
+              << ", got " << actual << " (path=" << p << ")\n";
+    return 1;
+  }
+  std::cout << "PASS: " << label << " (path=" << p << ", exists=" << actual
+            << ")\n";
+  return 0;
+}
+
+} // namespace
+
+void test_cache_cleanup(MockIC &mockIC) {
+  using std::chrono::file_clock;
+  using std::chrono::hours;
+
+  std::string controller_principal{MOCKIC_CONTROLLER};
+  std::string anonymous_principal{"2vxsx-fae"};
+  bool silent_on_trap = true;
+
+  // didc encode '()'
+  const std::string EMPTY_INPUT = "4449444c0000";
+  // didc encode '(variant { Err = variant { Other = "Access Denied" } })'
+  const std::string ACCESS_DENIED_API_ERROR =
+      "4449444c026b01b0ad8fcd0c716b01c5fed20100010100000d4163636573732044656e696"
+      "564";
+
+  int extra_failures = 0;
+
+  std::cout << "\n========== test_cache_cleanup ==========\n";
+
+  // -----------------------------------------------------------------------
+  // Scenario 1: cache_cleanup_now is a no-op when all files are fresh.
+  // -----------------------------------------------------------------------
+  clear_test_dir();
+  {
+    auto fresh = file_clock::now() - hours{1}; // 1h old, TTL is 6h
+    create_test_file(session_path("fresh_a.cache"), fresh);
+    create_test_file(session_path("fresh_b.cache"), fresh);
+    create_test_file(session_path("fresh_c.cache"), fresh);
+
+    uint64_t runs_before = g_cleanup_runs;
+    run_cache_cleanup_body();
+
+    // runs is a lifetime counter — assert delta. files_* are last-run only —
+    // assert absolute (overwritten on every cleanup invocation).
+    extra_failures += expect_eq_u64(
+        "[no-op fresh] runs delta", g_cleanup_runs - runs_before, 1);
+    extra_failures += expect_eq_u64("[no-op fresh] files_deleted (last run)",
+                                    g_cleanup_files_deleted, 0);
+    extra_failures += expect_eq_u64("[no-op fresh] files_failed (last run)",
+                                    g_cleanup_files_failed, 0);
+    extra_failures += expect_eq_u64("[no-op fresh] files_examined (last run)",
+                                    g_cleanup_files_examined, 3);
+    extra_failures += expect_file_exists("[no-op fresh] fresh_a.cache survives",
+                                         session_path("fresh_a.cache"), true);
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 2: cache_cleanup_now deletes stale files, keeps fresh.
+  // -----------------------------------------------------------------------
+  clear_test_dir();
+  {
+    auto fresh = file_clock::now() - hours{1};   // 1h
+    auto stale = file_clock::now() - hours{7};   // 7h, > 6h TTL
+    create_test_file(session_path("fresh_1.cache"), fresh);
+    create_test_file(session_path("fresh_2.cache"), fresh);
+    create_test_file(session_path("stale_1.cache"), stale);
+    create_test_file(session_path("stale_2.cache"), stale);
+    create_test_file(session_path("stale_3.cache"), stale);
+
+    run_cache_cleanup_body();
+
+    extra_failures += expect_eq_u64("[stale-mix] files_deleted (last run)",
+                                    g_cleanup_files_deleted, 3);
+    extra_failures += expect_eq_u64("[stale-mix] files_examined (last run)",
+                                    g_cleanup_files_examined, 5);
+    extra_failures += expect_file_exists("[stale-mix] fresh_1 survives",
+                                         session_path("fresh_1.cache"), true);
+    extra_failures += expect_file_exists("[stale-mix] stale_1 deleted",
+                                         session_path("stale_1.cache"), false);
+    extra_failures += expect_file_exists("[stale-mix] stale_3 deleted",
+                                         session_path("stale_3.cache"), false);
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 3: Cleanup honors the "sessions/" parent-dir filter — files
+  // under db_chats/ (or any other sibling) are NOT touched even when stale.
+  // -----------------------------------------------------------------------
+  clear_test_dir();
+  {
+    auto stale = file_clock::now() - hours{7};
+    create_test_file(session_path("stale_in_sessions.cache"), stale);
+    create_test_file(db_chats_path("stale_in_db_chats.txt"), stale);
+
+    run_cache_cleanup_body();
+
+    extra_failures += expect_eq_u64(
+        "[scope] files_deleted (last run, only sessions/* counted)",
+        g_cleanup_files_deleted, 1);
+    extra_failures += expect_file_exists(
+        "[scope] sessions/stale removed",
+        session_path("stale_in_sessions.cache"), false);
+    extra_failures += expect_file_exists(
+        "[scope] db_chats/stale UNTOUCHED",
+        db_chats_path("stale_in_db_chats.txt"), true);
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 4: Per-tick cap is honored. With 10 stale files and the cap
+  // set to 3, a single body invocation deletes exactly 3.
+  // -----------------------------------------------------------------------
+  clear_test_dir();
+  {
+    auto stale = file_clock::now() - hours{7};
+    for (int i = 0; i < 10; ++i) {
+      create_test_file(
+          session_path("capped_" + std::to_string(i) + ".cache"), stale);
+    }
+
+    uint64_t saved_cap = g_cleanup_max_files_per_run;
+    g_cleanup_max_files_per_run = 3;
+
+    run_cache_cleanup_body();
+
+    extra_failures += expect_eq_u64(
+        "[cap=3] files_deleted (last run) after one tick",
+        g_cleanup_files_deleted, 3);
+    extra_failures += expect_eq_u64(
+        "[cap=3] files_examined (last run) bounded by cap",
+        g_cleanup_files_examined, 3);
+
+    // Restore the default cap so subsequent tests are not affected.
+    g_cleanup_max_files_per_run = saved_cap;
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 4b: TTL config controls deletion. Set TTL=2h, create files
+  // straddling the 2h boundary, run the body, and verify exactly the
+  // stale-side files are deleted. Proves age-vs-ttl arithmetic is honest
+  // and that set_cache_cleanup_config(ttl_seconds=...) genuinely changes
+  // behavior — not just stored as a number.
+  // -----------------------------------------------------------------------
+  clear_test_dir();
+  {
+    using std::chrono::minutes;
+    uint64_t saved_ttl = g_cleanup_ttl_ns;
+    g_cleanup_ttl_ns = 2ULL * 3600 * 1'000'000'000ULL; // 2h
+
+    auto t_now = file_clock::now();
+    create_test_file(session_path("ttl_age_1h.cache"), t_now - hours{1});
+    create_test_file(session_path("ttl_age_119min.cache"),
+                     t_now - minutes{119});
+    create_test_file(session_path("ttl_age_121min.cache"),
+                     t_now - minutes{121});
+    create_test_file(session_path("ttl_age_3h.cache"), t_now - hours{3});
+
+    run_cache_cleanup_body();
+
+    extra_failures += expect_eq_u64(
+        "[ttl=2h] files_examined (last run) == 4 (all four scanned)",
+        g_cleanup_files_examined, 4);
+    extra_failures += expect_eq_u64(
+        "[ttl=2h] files_deleted (last run) == 2 (only the >2h ones)",
+        g_cleanup_files_deleted, 2);
+    extra_failures +=
+        expect_file_exists("[ttl=2h] 1h file kept (well-fresh)",
+                           session_path("ttl_age_1h.cache"), true);
+    extra_failures += expect_file_exists(
+        "[ttl=2h] 119min file kept (just-fresh, 1 min before TTL)",
+        session_path("ttl_age_119min.cache"), true);
+    extra_failures += expect_file_exists(
+        "[ttl=2h] 121min file deleted (just-stale, 1 min after TTL)",
+        session_path("ttl_age_121min.cache"), false);
+    extra_failures +=
+        expect_file_exists("[ttl=2h] 3h file deleted (well-stale)",
+                           session_path("ttl_age_3h.cache"), false);
+
+    g_cleanup_ttl_ns = saved_ttl;
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 4c: Recurring timer actually fires the cleanup body after the
+  // configured period elapses, driven through IcTimers::dispatch_due. We
+  // pin IC_API::time() (which the timer scheduler uses for deadline math)
+  // via ic0mock_set_time_override so the test is fully deterministic — no
+  // wall-clock sleeps. The cleanup body's age comparison uses host
+  // file_clock and is independent of the IC time override; with no files
+  // in the directory, the body just bumps g_cleanup_runs.
+  // -----------------------------------------------------------------------
+  clear_test_dir();
+  IC_API::cancel_all_timers();
+  {
+    uint64_t saved_period = g_cleanup_period_ns;
+    g_cleanup_period_ns = 1; // 1ns period — first deadline = now + 1
+
+    ic0mock_set_time_override(1000);
+    uint64_t runs_before = g_cleanup_runs;
+
+    // Arm the recurring timer at IC time 1000.
+    mockIC.run_test("cache_cleanup_start_timer (timer-fires scenario)",
+                    cache_cleanup_start_timer, EMPTY_INPUT, "",
+                    silent_on_trap, controller_principal);
+    extra_failures += expect_eq_u64(
+        "[timer-fires] timer registered after start_timer",
+        IcTimers::instance().size(), 1);
+
+    // Advance IC time past the deadline (1000 + 1 = 1001) and dispatch.
+    ic0mock_set_time_override(2000);
+    IcTimers::instance().dispatch_due(IC_API::time());
+
+    extra_failures += expect_eq_u64(
+        "[timer-fires] cleanup body ran exactly once via timer dispatch",
+        g_cleanup_runs - runs_before, 1);
+
+    // A second dispatch at the same now fires again (recurring with 1ns
+    // period leaves the next deadline at 1001 + advance*period; advance
+    // is computed in the catch-up math which always lands strictly past
+    // now_ns). Drive a third dispatch with a further-advanced clock to
+    // confirm the recurring nature: a one-shot would NOT fire again.
+    ic0mock_set_time_override(3000);
+    IcTimers::instance().dispatch_due(IC_API::time());
+    extra_failures += expect_eq_u64(
+        "[timer-fires] recurring fires again after another period elapses",
+        g_cleanup_runs - runs_before, 2);
+
+    // Cleanup
+    IC_API::cancel_all_timers();
+    g_cleanup_period_ns = saved_period;
+    ic0mock_clear_time_override();
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 5: cache_cleanup_start_timer arms the timer; cache_cleanup_stop_timer
+  // cancels it. Verified via IcTimers::instance().size().
+  // -----------------------------------------------------------------------
+  clear_test_dir();
+  IC_API::cancel_all_timers(); // start each scenario from a clean registry
+  {
+    extra_failures += expect_eq_u64(
+        "[start] timer registry empty pre-start",
+        IcTimers::instance().size(), 0);
+
+    mockIC.run_test("cache_cleanup_start_timer", cache_cleanup_start_timer, EMPTY_INPUT,
+                    "", silent_on_trap, controller_principal);
+
+    extra_failures += expect_eq_u64(
+        "[start] timer registry size == 1 after start",
+        IcTimers::instance().size(), 1);
+
+    // Idempotent: second start should not double-register.
+    mockIC.run_test("cache_cleanup_start_timer (idempotent)", cache_cleanup_start_timer,
+                    EMPTY_INPUT, "", silent_on_trap, controller_principal);
+
+    extra_failures += expect_eq_u64(
+        "[idempotent] timer registry size still 1 after second start",
+        IcTimers::instance().size(), 1);
+
+    mockIC.run_test("cache_cleanup_stop_timer", cache_cleanup_stop_timer, EMPTY_INPUT, "",
+                    silent_on_trap, controller_principal);
+
+    extra_failures += expect_eq_u64(
+        "[stop] timer registry size == 0 after stop",
+        IcTimers::instance().size(), 0);
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 6: Anonymous principal cannot call any of the admin endpoints;
+  // each returns the project's ACCESS_DENIED_API_ERROR variant. The query
+  // endpoint (get_cache_cleanup_stats) is also gated.
+  // -----------------------------------------------------------------------
+  IC_API::cancel_all_timers();
+  {
+    uint64_t runs_before = g_cleanup_runs;
+
+    mockIC.run_test("cache_cleanup_start_timer (anon denied)", cache_cleanup_start_timer,
+                    EMPTY_INPUT, ACCESS_DENIED_API_ERROR, silent_on_trap,
+                    anonymous_principal);
+    mockIC.run_test("cache_cleanup_stop_timer (anon denied)", cache_cleanup_stop_timer,
+                    EMPTY_INPUT, ACCESS_DENIED_API_ERROR, silent_on_trap,
+                    anonymous_principal);
+    mockIC.run_test("cache_cleanup_now (anon denied)", cache_cleanup_now,
+                    EMPTY_INPUT, ACCESS_DENIED_API_ERROR, silent_on_trap,
+                    anonymous_principal);
+    mockIC.run_test("get_cache_cleanup_stats (anon denied)",
+                    get_cache_cleanup_stats, EMPTY_INPUT,
+                    ACCESS_DENIED_API_ERROR, silent_on_trap,
+                    anonymous_principal);
+    // set_cache_cleanup_config takes a non-empty input record. Auth is
+    // checked BEFORE from_wire, so an EMPTY_INPUT still triggers the auth
+    // path correctly (the function returns before attempting to decode).
+    mockIC.run_test("set_cache_cleanup_config (anon denied)",
+                    set_cache_cleanup_config, EMPTY_INPUT,
+                    ACCESS_DENIED_API_ERROR, silent_on_trap,
+                    anonymous_principal);
+
+    extra_failures += expect_eq_u64(
+        "[anon-denied] no cleanup runs occurred",
+        g_cleanup_runs - runs_before, 0);
+    extra_failures += expect_eq_u64(
+        "[anon-denied] timer registry still empty",
+        IcTimers::instance().size(), 0);
+  }
+
+  // Final cleanup so leftover state from this test does not affect later
+  // tests in the same mockic.exe run (test_qwen2 etc may scan filesystem).
+  clear_test_dir();
+  IC_API::cancel_all_timers();
+
+  std::cout << "test_cache_cleanup extra_failures: " << extra_failures
+            << "\n========================================\n\n";
+  if (extra_failures > 0) {
+    // Surface the failure count via mockIC's pass/fail summary by running a
+    // synthetic failing test. (mockIC.test_summary() returns 1 if any
+    // run_test failed; the extra_failures don't go through run_test.)
+    mockIC.run_test(
+        "test_cache_cleanup: extra_failures detected (see PASS/FAIL log above)",
+        cache_cleanup_now, EMPTY_INPUT, "DELIBERATE_FAIL_TO_RAISE_ALARM",
+        silent_on_trap, controller_principal);
+  }
+}

--- a/native/test_cache_cleanup.cpp
+++ b/native/test_cache_cleanup.cpp
@@ -142,8 +142,8 @@ void test_cache_cleanup(MockIC &mockIC) {
 
     // runs is a lifetime counter — assert delta. files_* are last-run only —
     // assert absolute (overwritten on every cleanup invocation).
-    extra_failures += expect_eq_u64(
-        "[no-op fresh] runs delta", g_cleanup_runs - runs_before, 1);
+    extra_failures += expect_eq_u64("[no-op fresh] runs delta",
+                                    g_cleanup_runs - runs_before, 1);
     extra_failures += expect_eq_u64("[no-op fresh] files_deleted (last run)",
                                     g_cleanup_files_deleted, 0);
     extra_failures += expect_eq_u64("[no-op fresh] files_failed (last run)",
@@ -159,8 +159,8 @@ void test_cache_cleanup(MockIC &mockIC) {
   // -----------------------------------------------------------------------
   clear_test_dir();
   {
-    auto fresh = file_clock::now() - hours{1};   // 1h
-    auto stale = file_clock::now() - hours{7};   // 7h, > 6h TTL
+    auto fresh = file_clock::now() - hours{1}; // 1h
+    auto stale = file_clock::now() - hours{7}; // 7h, > 6h TTL
     create_test_file(session_path("fresh_1.cache"), fresh);
     create_test_file(session_path("fresh_2.cache"), fresh);
     create_test_file(session_path("stale_1.cache"), stale);
@@ -196,12 +196,12 @@ void test_cache_cleanup(MockIC &mockIC) {
     extra_failures += expect_eq_u64(
         "[scope] files_deleted (last run, only sessions/* counted)",
         g_cleanup_files_deleted, 1);
-    extra_failures += expect_file_exists(
-        "[scope] sessions/stale removed",
-        session_path("stale_in_sessions.cache"), false);
-    extra_failures += expect_file_exists(
-        "[scope] db_chats/stale UNTOUCHED",
-        db_chats_path("stale_in_db_chats.txt"), true);
+    extra_failures +=
+        expect_file_exists("[scope] sessions/stale removed",
+                           session_path("stale_in_sessions.cache"), false);
+    extra_failures +=
+        expect_file_exists("[scope] db_chats/stale UNTOUCHED",
+                           db_chats_path("stale_in_db_chats.txt"), true);
   }
 
   // -----------------------------------------------------------------------
@@ -212,8 +212,8 @@ void test_cache_cleanup(MockIC &mockIC) {
   {
     auto stale = file_clock::now() - hours{7};
     for (int i = 0; i < 10; ++i) {
-      create_test_file(
-          session_path("capped_" + std::to_string(i) + ".cache"), stale);
+      create_test_file(session_path("capped_" + std::to_string(i) + ".cache"),
+                       stale);
     }
 
     uint64_t saved_cap = g_cleanup_max_files_per_run;
@@ -221,12 +221,12 @@ void test_cache_cleanup(MockIC &mockIC) {
 
     run_cache_cleanup_body();
 
-    extra_failures += expect_eq_u64(
-        "[cap=3] files_deleted (last run) after one tick",
-        g_cleanup_files_deleted, 3);
-    extra_failures += expect_eq_u64(
-        "[cap=3] files_examined (last run) bounded by cap",
-        g_cleanup_files_examined, 3);
+    extra_failures +=
+        expect_eq_u64("[cap=3] files_deleted (last run) after one tick",
+                      g_cleanup_files_deleted, 3);
+    extra_failures +=
+        expect_eq_u64("[cap=3] files_examined (last run) bounded by cap",
+                      g_cleanup_files_examined, 3);
 
     // Restore the default cap so subsequent tests are not affected.
     g_cleanup_max_files_per_run = saved_cap;
@@ -297,11 +297,11 @@ void test_cache_cleanup(MockIC &mockIC) {
 
     // Arm the recurring timer at IC time 1000.
     mockIC.run_test("cache_cleanup_start_timer (timer-fires scenario)",
-                    cache_cleanup_start_timer, EMPTY_INPUT, "",
-                    silent_on_trap, controller_principal);
-    extra_failures += expect_eq_u64(
-        "[timer-fires] timer registered after start_timer",
-        IcTimers::instance().size(), 1);
+                    cache_cleanup_start_timer, EMPTY_INPUT, "", silent_on_trap,
+                    controller_principal);
+    extra_failures +=
+        expect_eq_u64("[timer-fires] timer registered after start_timer",
+                      IcTimers::instance().size(), 1);
 
     // Advance IC time past the deadline (1000 + 1 = 1001) and dispatch.
     ic0mock_set_time_override(2000);
@@ -335,31 +335,31 @@ void test_cache_cleanup(MockIC &mockIC) {
   clear_test_dir();
   IC_API::cancel_all_timers(); // start each scenario from a clean registry
   {
-    extra_failures += expect_eq_u64(
-        "[start] timer registry empty pre-start",
-        IcTimers::instance().size(), 0);
+    extra_failures += expect_eq_u64("[start] timer registry empty pre-start",
+                                    IcTimers::instance().size(), 0);
 
-    mockIC.run_test("cache_cleanup_start_timer", cache_cleanup_start_timer, EMPTY_INPUT,
-                    "", silent_on_trap, controller_principal);
+    mockIC.run_test("cache_cleanup_start_timer", cache_cleanup_start_timer,
+                    EMPTY_INPUT, "", silent_on_trap, controller_principal);
 
-    extra_failures += expect_eq_u64(
-        "[start] timer registry size == 1 after start",
-        IcTimers::instance().size(), 1);
+    extra_failures +=
+        expect_eq_u64("[start] timer registry size == 1 after start",
+                      IcTimers::instance().size(), 1);
 
     // Idempotent: second start should not double-register.
-    mockIC.run_test("cache_cleanup_start_timer (idempotent)", cache_cleanup_start_timer,
-                    EMPTY_INPUT, "", silent_on_trap, controller_principal);
+    mockIC.run_test("cache_cleanup_start_timer (idempotent)",
+                    cache_cleanup_start_timer, EMPTY_INPUT, "", silent_on_trap,
+                    controller_principal);
 
     extra_failures += expect_eq_u64(
         "[idempotent] timer registry size still 1 after second start",
         IcTimers::instance().size(), 1);
 
-    mockIC.run_test("cache_cleanup_stop_timer", cache_cleanup_stop_timer, EMPTY_INPUT, "",
-                    silent_on_trap, controller_principal);
+    mockIC.run_test("cache_cleanup_stop_timer", cache_cleanup_stop_timer,
+                    EMPTY_INPUT, "", silent_on_trap, controller_principal);
 
-    extra_failures += expect_eq_u64(
-        "[stop] timer registry size == 0 after stop",
-        IcTimers::instance().size(), 0);
+    extra_failures +=
+        expect_eq_u64("[stop] timer registry size == 0 after stop",
+                      IcTimers::instance().size(), 0);
   }
 
   // -----------------------------------------------------------------------
@@ -371,11 +371,13 @@ void test_cache_cleanup(MockIC &mockIC) {
   {
     uint64_t runs_before = g_cleanup_runs;
 
-    mockIC.run_test("cache_cleanup_start_timer (anon denied)", cache_cleanup_start_timer,
-                    EMPTY_INPUT, ACCESS_DENIED_API_ERROR, silent_on_trap,
+    mockIC.run_test("cache_cleanup_start_timer (anon denied)",
+                    cache_cleanup_start_timer, EMPTY_INPUT,
+                    ACCESS_DENIED_API_ERROR, silent_on_trap,
                     anonymous_principal);
-    mockIC.run_test("cache_cleanup_stop_timer (anon denied)", cache_cleanup_stop_timer,
-                    EMPTY_INPUT, ACCESS_DENIED_API_ERROR, silent_on_trap,
+    mockIC.run_test("cache_cleanup_stop_timer (anon denied)",
+                    cache_cleanup_stop_timer, EMPTY_INPUT,
+                    ACCESS_DENIED_API_ERROR, silent_on_trap,
                     anonymous_principal);
     mockIC.run_test("cache_cleanup_now (anon denied)", cache_cleanup_now,
                     EMPTY_INPUT, ACCESS_DENIED_API_ERROR, silent_on_trap,
@@ -392,12 +394,10 @@ void test_cache_cleanup(MockIC &mockIC) {
                     ACCESS_DENIED_API_ERROR, silent_on_trap,
                     anonymous_principal);
 
-    extra_failures += expect_eq_u64(
-        "[anon-denied] no cleanup runs occurred",
-        g_cleanup_runs - runs_before, 0);
-    extra_failures += expect_eq_u64(
-        "[anon-denied] timer registry still empty",
-        IcTimers::instance().size(), 0);
+    extra_failures += expect_eq_u64("[anon-denied] no cleanup runs occurred",
+                                    g_cleanup_runs - runs_before, 0);
+    extra_failures += expect_eq_u64("[anon-denied] timer registry still empty",
+                                    IcTimers::instance().size(), 0);
   }
 
   // Final cleanup so leftover state from this test does not affect later

--- a/native/test_cache_cleanup.h
+++ b/native/test_cache_cleanup.h
@@ -1,0 +1,3 @@
+#pragma once
+#include "mock_ic.h"
+void test_cache_cleanup(MockIC &mockIC);

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@
 
 -r scripts/requirements.txt
 -r src/llama_cpp_onicai_fork/requirements.txt
-icpp-pro>=5.3.1
+icpp-pro>=5.4.1
 icp-py-core==2.3.0
 binaryen.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,8 @@
 -r src/llama_cpp_onicai_fork/requirements.txt
 icpp-pro>=5.4.1
 icp-py-core==2.3.0
+# Pin cbor2<6: cbor2 6.x decodes tag-55799-wrapped maps to frozendict, which
+# breaks icp-py-core's isinstance(response, dict) check.
+# See https://github.com/eliezhao/icp-py-core/issues/14.
+cbor2<6
 binaryen.py

--- a/scripts/ic_py_canister.py
+++ b/scripts/ic_py_canister.py
@@ -1,5 +1,6 @@
 """Returns the icp-py-core Canister instance, for calling the endpoints."""
 
+import re
 import sys
 import subprocess
 from pathlib import Path
@@ -11,6 +12,20 @@ ROOT_PATH = Path(__file__).parent.parent
 
 # We use dfx to get some information.
 DFX = "dfx"
+
+# dfx 0.32.0 emits this deprecation banner on every invocation. Because
+# run_shell_cmd merges stderr into stdout, the banner ends up in the
+# captured output and gets glued onto things like the identity name —
+# corrupting the next dfx call's arguments. Strip exactly this known line.
+# Mirrors the fix in icpp-pro src/icpp/smoketest.py (commit 6f401c4).
+_DFX_DEPRECATION_RE = re.compile(
+    r"^WARNING: dfx is deprecated.*$\n?", flags=re.MULTILINE
+)
+
+
+def _strip_dfx_warnings(s: str) -> str:
+    """Remove the known dfx deprecation banner from captured shell output."""
+    return _DFX_DEPRECATION_RE.sub("", s)
 
 
 def extract_variant(response: List[Any]) -> Any:
@@ -29,7 +44,9 @@ def extract_variant(response: List[Any]) -> Any:
 def run_dfx_command(cmd: str, quiet: bool = False) -> Optional[str]:
     """Runs dfx command as a subprocess"""
     try:
-        return run_shell_cmd(cmd, capture_output=True).rstrip("\n")
+        return _strip_dfx_warnings(
+            run_shell_cmd(cmd, capture_output=True)
+        ).rstrip("\n")
     except subprocess.CalledProcessError as e:
         if not quiet:
             print(f"Failed dfx command: '{cmd}' with error: \n{e.output}")

--- a/scripts/ic_py_canister.py
+++ b/scripts/ic_py_canister.py
@@ -44,9 +44,7 @@ def extract_variant(response: List[Any]) -> Any:
 def run_dfx_command(cmd: str, quiet: bool = False) -> Optional[str]:
     """Runs dfx command as a subprocess"""
     try:
-        return _strip_dfx_warnings(
-            run_shell_cmd(cmd, capture_output=True)
-        ).rstrip("\n")
+        return _strip_dfx_warnings(run_shell_cmd(cmd, capture_output=True)).rstrip("\n")
     except subprocess.CalledProcessError as e:
         if not quiet:
             print(f"Failed dfx command: '{cmd}' with error: \n{e.output}")

--- a/scripts/optimize_wasm.py
+++ b/scripts/optimize_wasm.py
@@ -34,7 +34,8 @@ def load_wasm(wasm_path: Path) -> binaryen.module.Module:
     """Load a WebAssembly binary into a binaryen module"""
 
     # Read the binary wasm into a bytes array
-    wasm_bytes = open(wasm_path, "rb").read()
+    with open(wasm_path, "rb") as f:
+        wasm_bytes = f.read()
 
     # Convert the binary data to a C data type that Binaryen can understand
     wasm_ptr = ffi.new("char[]", wasm_bytes)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,6 +2,11 @@ ipykernel
 jupyter_black
 requests
 python-dotenv
-black
-mypy
-pylint==2.13.9
+
+# Pinned to the same versions used by icpp-pro after its Python 3.10–3.14
+# matrix bump. Keeping all three repos on the same toolchain avoids style/
+# check drift across PRs. Older pylint+astroid crashed on Python 3.12+
+# syntax (PEP 695 `type X = ...`).
+black==24.10.0
+pylint==3.3.4
+mypy==1.13.0

--- a/src/cache_cleanup.cpp
+++ b/src/cache_cleanup.cpp
@@ -1,0 +1,348 @@
+// Recurring prompt-cache cleanup timer — implementation.
+// See cache_cleanup.h for the high-level contract.
+
+#include "cache_cleanup.h"
+
+#include "auth.h"
+#include "ic_api.h"
+#include "upload.h"
+
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <limits>
+#include <optional>
+#include <system_error>
+
+// --- Defaults & bounds ---------------------------------------------------
+namespace {
+constexpr uint64_t NS_PER_SEC = 1'000'000'000ULL;
+constexpr uint64_t MAX_SECONDS = std::numeric_limits<uint64_t>::max() / NS_PER_SEC;
+
+constexpr uint64_t DEFAULT_PERIOD_NS = 600ULL * NS_PER_SEC;       // 10 min
+constexpr uint64_t DEFAULT_TTL_NS = 6ULL * 3600 * NS_PER_SEC;     // 6 h
+constexpr uint64_t DEFAULT_MAX_FILES_PER_RUN = 256;
+
+constexpr uint64_t MAX_FILES_PER_RUN_FLOOR = 1;
+constexpr uint64_t MAX_FILES_PER_RUN_CEILING = 10'000;
+} // namespace
+
+// --- File-scope state (extern in cache_cleanup.h for native-test access) -
+//
+// Two flavors of stats:
+//   - LIFETIME counters (monotonic, accumulate over the canister's life):
+//       g_cleanup_runs        — total number of cleanup invocations
+//       g_cleanup_last_run_ns — timestamp of the most recent invocation
+//   - LAST-RUN stats (overwritten on every cleanup invocation):
+//       g_cleanup_files_examined — files inspected in the most recent run
+//       g_cleanup_files_deleted  — files removed in the most recent run
+//       g_cleanup_files_failed   — failures in the most recent run
+// The last-run flavor matches the natural reading of those field names in
+// the candid stats record: callers want "what did the last cleanup do?",
+// not "what is the lifetime total?". If a lifetime total is needed later,
+// add separate `g_cleanup_total_files_*` counters alongside.
+uint64_t g_cleanup_runs = 0;
+uint64_t g_cleanup_files_examined = 0;
+uint64_t g_cleanup_files_deleted = 0;
+uint64_t g_cleanup_files_failed = 0;
+uint64_t g_cleanup_last_run_ns = 0;
+uint64_t g_cleanup_period_ns = DEFAULT_PERIOD_NS;
+uint64_t g_cleanup_ttl_ns = DEFAULT_TTL_NS;
+uint64_t g_cleanup_max_files_per_run = DEFAULT_MAX_FILES_PER_RUN;
+uint64_t g_cleanup_timer_id = 0;
+
+namespace {
+
+// Re-arm the recurring timer with the current g_cleanup_period_ns.
+// Caller must have first cancelled any existing timer (id stored in
+// g_cleanup_timer_id).
+void arm_timer_() {
+  g_cleanup_timer_id = IC_API::set_timer_recurring(
+      g_cleanup_period_ns, []() { run_cache_cleanup_body(); });
+}
+
+// Helper: append the current stats to a CandidTypeRecord. Used by the
+// cache_cleanup_now and get_cache_cleanup_stats endpoints to construct
+// their return record consistently.
+CandidTypeRecord build_stats_record_() {
+  CandidTypeRecord r;
+  r.append("runs", CandidTypeNat64{g_cleanup_runs});
+  r.append("files_examined", CandidTypeNat64{g_cleanup_files_examined});
+  r.append("files_deleted", CandidTypeNat64{g_cleanup_files_deleted});
+  r.append("files_failed", CandidTypeNat64{g_cleanup_files_failed});
+  r.append("last_run_ns", CandidTypeNat64{g_cleanup_last_run_ns});
+  r.append("period_seconds", CandidTypeNat64{g_cleanup_period_ns / NS_PER_SEC});
+  r.append("ttl_seconds", CandidTypeNat64{g_cleanup_ttl_ns / NS_PER_SEC});
+  r.append("max_files_per_run", CandidTypeNat64{g_cleanup_max_files_per_run});
+  r.append("is_running", CandidTypeBool{g_cleanup_timer_id != 0});
+  return r;
+}
+
+CandidTypeRecord build_config_record_() {
+  CandidTypeRecord r;
+  r.append("period_seconds", CandidTypeNat64{g_cleanup_period_ns / NS_PER_SEC});
+  r.append("ttl_seconds", CandidTypeNat64{g_cleanup_ttl_ns / NS_PER_SEC});
+  r.append("max_files_per_run", CandidTypeNat64{g_cleanup_max_files_per_run});
+  r.append("is_running", CandidTypeBool{g_cleanup_timer_id != 0});
+  return r;
+}
+
+CandidTypeRecord build_action_record_() {
+  CandidTypeRecord r;
+  r.append("ok", CandidTypeBool{true});
+  r.append("is_running", CandidTypeBool{g_cleanup_timer_id != 0});
+  return r;
+}
+
+} // namespace
+
+// --- Cleanup body ---------------------------------------------------------
+//
+// Walks `.canister_cache/<principal>/sessions/` using two explicit levels of
+// non-recursive directory_iterator: outer over principal subdirectories,
+// inner over each principal's sessions/ files. The two-level walk maps 1:1
+// to the on-disk layout and is structurally clearer than a recursive walk
+// with a parent-dir-name filter.
+//
+// Age is computed in the host file_clock domain, NEVER mixed with
+// IC_API::time(). Bounded by g_cleanup_max_files_per_run; if we hit the
+// cap, the next tick continues from the start of the directory tree
+// (bounded repeated scanning, not cursor-based — acceptable for v1).
+void run_cache_cleanup_body() {
+  using std::chrono::file_clock;
+  using std::chrono::nanoseconds;
+  using std::chrono::duration_cast;
+
+  uint64_t examined = 0, deleted = 0, failed = 0;
+
+  std::error_code ec_outer;
+  std::filesystem::directory_iterator outer(".canister_cache", ec_outer);
+  if (ec_outer) {
+    // No .canister_cache yet — fresh canister, first run.
+    ++g_cleanup_runs;
+    g_cleanup_files_examined = 0;
+    g_cleanup_files_deleted = 0;
+    g_cleanup_files_failed = 0;
+    g_cleanup_last_run_ns = IC_API::time();
+    return;
+  }
+
+  const auto outer_end = std::filesystem::directory_iterator{};
+  for (; outer != outer_end && examined < g_cleanup_max_files_per_run;) {
+    const auto principal_path = outer->path();
+
+    std::error_code ec;
+    bool is_dir = outer->is_directory(ec);
+    if (ec || !is_dir) {
+      std::error_code adv_ec;
+      outer.increment(adv_ec);
+      if (adv_ec) break;
+      continue;
+    }
+
+    auto sessions_path = principal_path / "sessions";
+    std::error_code sess_ec;
+    if (!std::filesystem::is_directory(sessions_path, sess_ec) || sess_ec) {
+      std::error_code adv_ec;
+      outer.increment(adv_ec);
+      if (adv_ec) break;
+      continue;
+    }
+
+    std::error_code ec_inner;
+    std::filesystem::directory_iterator inner(sessions_path, ec_inner);
+    if (ec_inner) {
+      std::error_code adv_ec;
+      outer.increment(adv_ec);
+      if (adv_ec) break;
+      continue;
+    }
+
+    const auto inner_end = std::filesystem::directory_iterator{};
+    for (; inner != inner_end && examined < g_cleanup_max_files_per_run;) {
+      const auto file_path = inner->path();
+
+      std::error_code ec_ftype;
+      bool is_file = inner->is_regular_file(ec_ftype);
+      if (ec_ftype || !is_file) {
+        std::error_code adv_ec;
+        inner.increment(adv_ec);
+        if (adv_ec) break;
+        continue;
+      }
+
+      ++examined;
+
+      std::error_code ec_mtime;
+      auto mtime = std::filesystem::last_write_time(file_path, ec_mtime);
+      if (ec_mtime) {
+        ++failed;
+        std::error_code adv_ec;
+        inner.increment(adv_ec);
+        if (adv_ec) break;
+        continue;
+      }
+
+      // Age in nanoseconds, computed in file_clock domain.
+      // Pattern mirrors src/files.cpp:276-281.
+      auto now_tp = file_clock::now();
+      auto age_ns = duration_cast<nanoseconds>(
+                        now_tp.time_since_epoch() - mtime.time_since_epoch())
+                        .count();
+      bool stale = (age_ns >= 0) &&
+                   static_cast<uint64_t>(age_ns) >= g_cleanup_ttl_ns;
+
+      if (stale) {
+        std::error_code ec_rm;
+        if (!std::filesystem::remove(file_path, ec_rm) || ec_rm) {
+          ++failed;
+        } else {
+          ++deleted;
+          // Pair the file-delete with metadata-delete. A false return means
+          // no metadata record matched (fine if upload tracking did not
+          // record this file). Best-effort: we do not escalate "no record"
+          // to ++failed.
+          (void)delete_file_metadata(file_path.string());
+        }
+      }
+
+      std::error_code adv_ec;
+      inner.increment(adv_ec);
+      if (adv_ec) break;
+    }
+
+    std::error_code adv_ec;
+    outer.increment(adv_ec);
+    if (adv_ec) break;
+  }
+
+  ++g_cleanup_runs;
+  // Last-run stats: assign, do not accumulate. Each invocation overwrites
+  // the previous run's numbers; callers reading the stats record see the
+  // most recent run's outcome.
+  g_cleanup_files_examined = examined;
+  g_cleanup_files_deleted = deleted;
+  g_cleanup_files_failed = failed;
+  g_cleanup_last_run_ns = IC_API::time(); // reporting only, not for age math.
+}
+
+// --- Endpoints ------------------------------------------------------------
+
+void cache_cleanup_start_timer() {
+  IC_API ic_api(CanisterUpdate{std::string(__func__)}, false);
+  if (!has_admin_update_role(ic_api)) {
+    send_access_denied_api_error(ic_api);
+    return;
+  }
+  ic_api.from_wire();
+
+  // Idempotent: cancel any existing armed timer before re-arming.
+  if (g_cleanup_timer_id != 0) {
+    IC_API::cancel_timer(g_cleanup_timer_id);
+  }
+  arm_timer_();
+
+  ic_api.to_wire(
+      CandidTypeVariant{"Ok", CandidTypeRecord{build_action_record_()}});
+}
+
+void cache_cleanup_stop_timer() {
+  IC_API ic_api(CanisterUpdate{std::string(__func__)}, false);
+  if (!has_admin_update_role(ic_api)) {
+    send_access_denied_api_error(ic_api);
+    return;
+  }
+  ic_api.from_wire();
+
+  if (g_cleanup_timer_id != 0) {
+    IC_API::cancel_timer(g_cleanup_timer_id);
+    g_cleanup_timer_id = 0;
+  }
+
+  ic_api.to_wire(
+      CandidTypeVariant{"Ok", CandidTypeRecord{build_action_record_()}});
+}
+
+void cache_cleanup_now() {
+  IC_API ic_api(CanisterUpdate{std::string(__func__)}, false);
+  if (!has_admin_update_role(ic_api)) {
+    send_access_denied_api_error(ic_api);
+    return;
+  }
+  ic_api.from_wire();
+
+  run_cache_cleanup_body();
+
+  ic_api.to_wire(
+      CandidTypeVariant{"Ok", CandidTypeRecord{build_stats_record_()}});
+}
+
+void get_cache_cleanup_stats() {
+  IC_API ic_api(CanisterQuery{std::string(__func__)}, false);
+  if (!has_admin_query_role(ic_api)) {
+    send_access_denied_api_error(ic_api);
+    return;
+  }
+  ic_api.from_wire();
+
+  ic_api.to_wire(
+      CandidTypeVariant{"Ok", CandidTypeRecord{build_stats_record_()}});
+}
+
+void set_cache_cleanup_config() {
+  IC_API ic_api(CanisterUpdate{std::string(__func__)}, false);
+  if (!has_admin_update_role(ic_api)) {
+    send_access_denied_api_error(ic_api);
+    return;
+  }
+
+  // CacheCleanupConfigInput is a record of three opt nat64 fields:
+  //   period_seconds   : opt nat64
+  //   ttl_seconds      : opt nat64
+  //   max_files_per_run: opt nat64
+  // Each opt:
+  //   - null       → no change
+  //   - opt N (>0) → applied (with bounds-clamp for max_files_per_run)
+  //   - opt 0      → field-specific:
+  //       * period_seconds   : silently rejected (would fire forever)
+  //       * ttl_seconds      : valid ("delete everything", used by tests)
+  //       * max_files_per_run: clamped to floor (1)
+  std::optional<uint64_t> opt_period_seconds;
+  std::optional<uint64_t> opt_ttl_seconds;
+  std::optional<uint64_t> opt_max_files;
+
+  CandidTypeRecord r_in;
+  r_in.append("period_seconds", CandidTypeOptNat64{&opt_period_seconds});
+  r_in.append("ttl_seconds", CandidTypeOptNat64{&opt_ttl_seconds});
+  r_in.append("max_files_per_run", CandidTypeOptNat64{&opt_max_files});
+  ic_api.from_wire(r_in);
+
+  // period_seconds: must be > 0; otherwise silently preserve.
+  if (opt_period_seconds.has_value() && *opt_period_seconds > 0 &&
+      *opt_period_seconds <= MAX_SECONDS) {
+    g_cleanup_period_ns = *opt_period_seconds * NS_PER_SEC;
+  }
+  // ttl_seconds: 0 is a valid "delete everything" value. Clamp by MAX_SECONDS.
+  if (opt_ttl_seconds.has_value() && *opt_ttl_seconds <= MAX_SECONDS) {
+    g_cleanup_ttl_ns = *opt_ttl_seconds * NS_PER_SEC;
+  }
+  // max_files_per_run: clamp to [floor, ceiling].
+  if (opt_max_files.has_value()) {
+    uint64_t v = *opt_max_files;
+    if (v < MAX_FILES_PER_RUN_FLOOR)
+      g_cleanup_max_files_per_run = MAX_FILES_PER_RUN_FLOOR;
+    else if (v > MAX_FILES_PER_RUN_CEILING)
+      g_cleanup_max_files_per_run = MAX_FILES_PER_RUN_CEILING;
+    else
+      g_cleanup_max_files_per_run = v;
+  }
+
+  // If currently armed, transparently re-arm with the new period.
+  if (g_cleanup_timer_id != 0) {
+    IC_API::cancel_timer(g_cleanup_timer_id);
+    arm_timer_();
+  }
+
+  ic_api.to_wire(
+      CandidTypeVariant{"Ok", CandidTypeRecord{build_config_record_()}});
+}

--- a/src/cache_cleanup.cpp
+++ b/src/cache_cleanup.cpp
@@ -17,10 +17,11 @@
 // --- Defaults & bounds ---------------------------------------------------
 namespace {
 constexpr uint64_t NS_PER_SEC = 1'000'000'000ULL;
-constexpr uint64_t MAX_SECONDS = std::numeric_limits<uint64_t>::max() / NS_PER_SEC;
+constexpr uint64_t MAX_SECONDS =
+    std::numeric_limits<uint64_t>::max() / NS_PER_SEC;
 
-constexpr uint64_t DEFAULT_PERIOD_NS = 600ULL * NS_PER_SEC;       // 10 min
-constexpr uint64_t DEFAULT_TTL_NS = 6ULL * 3600 * NS_PER_SEC;     // 6 h
+constexpr uint64_t DEFAULT_PERIOD_NS = 600ULL * NS_PER_SEC;   // 10 min
+constexpr uint64_t DEFAULT_TTL_NS = 6ULL * 3600 * NS_PER_SEC; // 6 h
 constexpr uint64_t DEFAULT_MAX_FILES_PER_RUN = 256;
 
 constexpr uint64_t MAX_FILES_PER_RUN_FLOOR = 1;
@@ -109,9 +110,9 @@ CandidTypeRecord build_action_record_() {
 // cap, the next tick continues from the start of the directory tree
 // (bounded repeated scanning, not cursor-based — acceptable for v1).
 void run_cache_cleanup_body() {
+  using std::chrono::duration_cast;
   using std::chrono::file_clock;
   using std::chrono::nanoseconds;
-  using std::chrono::duration_cast;
 
   uint64_t examined = 0, deleted = 0, failed = 0;
 
@@ -186,11 +187,11 @@ void run_cache_cleanup_body() {
       // Age in nanoseconds, computed in file_clock domain.
       // Pattern mirrors src/files.cpp:276-281.
       auto now_tp = file_clock::now();
-      auto age_ns = duration_cast<nanoseconds>(
-                        now_tp.time_since_epoch() - mtime.time_since_epoch())
+      auto age_ns = duration_cast<nanoseconds>(now_tp.time_since_epoch() -
+                                               mtime.time_since_epoch())
                         .count();
-      bool stale = (age_ns >= 0) &&
-                   static_cast<uint64_t>(age_ns) >= g_cleanup_ttl_ns;
+      bool stale =
+          (age_ns >= 0) && static_cast<uint64_t>(age_ns) >= g_cleanup_ttl_ns;
 
       if (stale) {
         std::error_code ec_rm;
@@ -333,8 +334,7 @@ void set_cache_cleanup_config() {
       g_cleanup_max_files_per_run = MAX_FILES_PER_RUN_FLOOR;
     else if (v > MAX_FILES_PER_RUN_CEILING)
       g_cleanup_max_files_per_run = MAX_FILES_PER_RUN_CEILING;
-    else
-      g_cleanup_max_files_per_run = v;
+    else g_cleanup_max_files_per_run = v;
   }
 
   // If currently armed, transparently re-arm with the new period.

--- a/src/cache_cleanup.h
+++ b/src/cache_cleanup.h
@@ -1,0 +1,61 @@
+// Recurring prompt-cache cleanup timer.
+//
+// Walks `.canister_cache/<principal>/sessions/` on a configurable schedule
+// (default: every 10 minutes) and deletes files whose mtime is older than a
+// configurable TTL (default: 6 hours). Each tick is bounded by
+// `g_max_files_per_run` to stay under the IC's per-message instruction
+// budget; the next tick continues the cleanup.
+//
+// Lifecycle is operator-driven: the timer is NOT auto-armed in
+// canister_init / canister_post_upgrade. The deploy/upgrade workflow must
+// explicitly call `cache_cleanup_start_timer` after the canister is
+// reachable. Timer state is in-memory only and does not survive an upgrade.
+#pragma once
+
+#include "wasm_symbol.h"
+
+#include <cstdint>
+
+// --- Endpoints ------------------------------------------------------------
+// Update endpoints — RBAC: has_admin_update_role required.
+void cache_cleanup_start_timer()
+    WASM_SYMBOL_EXPORTED("canister_update cache_cleanup_start_timer");
+void cache_cleanup_stop_timer()
+    WASM_SYMBOL_EXPORTED("canister_update cache_cleanup_stop_timer");
+void cache_cleanup_now()
+    WASM_SYMBOL_EXPORTED("canister_update cache_cleanup_now");
+void set_cache_cleanup_config()
+    WASM_SYMBOL_EXPORTED("canister_update set_cache_cleanup_config");
+
+// Query endpoint — RBAC: has_admin_query_role required.
+void get_cache_cleanup_stats()
+    WASM_SYMBOL_EXPORTED("canister_query get_cache_cleanup_stats");
+
+// --- Internal helper ------------------------------------------------------
+// Pure data + filesystem work. Safe to call from any context: an entry-point
+// handler that already has its own IC_API on the stack, OR the timer
+// callback (which runs inside canister_global_timer's CanisterGlobalTimer
+// IC_API frame). This function does NOT construct an IC_API instance.
+void run_cache_cleanup_body();
+
+// --- Test introspection (extern for native tests) ------------------------
+// These are file-scope statics in cache_cleanup.cpp; they are exposed via
+// extern declarations here exclusively so native tests in
+// native/test_cache_cleanup.cpp can read them directly without going
+// through Candid. Production code MUST NOT mutate them.
+//
+// Semantics — see cache_cleanup.cpp for the full comment:
+//   - LIFETIME (accumulate over the canister's life):
+//       g_cleanup_runs, g_cleanup_last_run_ns
+//   - LAST-RUN (overwritten on every cleanup invocation):
+//       g_cleanup_files_examined, g_cleanup_files_deleted,
+//       g_cleanup_files_failed
+extern uint64_t g_cleanup_runs;
+extern uint64_t g_cleanup_files_examined;
+extern uint64_t g_cleanup_files_deleted;
+extern uint64_t g_cleanup_files_failed;
+extern uint64_t g_cleanup_last_run_ns;
+extern uint64_t g_cleanup_period_ns;
+extern uint64_t g_cleanup_ttl_ns;
+extern uint64_t g_cleanup_max_files_per_run;
+extern uint64_t g_cleanup_timer_id;

--- a/src/llama_cpp.did
+++ b/src/llama_cpp.did
@@ -243,6 +243,53 @@ type FileEntry = record {
 };
 
 // -----------------------------------------------------
+// Recurring prompt-cache cleanup timer
+type CacheCleanupResult = variant {
+  Err : ApiError;
+  Ok : CacheCleanupActionRecord
+};
+type CacheCleanupActionRecord = record {
+  ok : bool;
+  is_running : bool
+};
+
+type CacheCleanupStatsResult = variant {
+  Err : ApiError;
+  Ok : CacheCleanupStatsRecord
+};
+type CacheCleanupStatsRecord = record {
+  runs : nat64;
+  files_examined : nat64;
+  files_deleted : nat64;
+  files_failed : nat64;
+  last_run_ns : nat64;       // host-clock timestamp via IC_API::time(); reporting only
+  period_seconds : nat64;
+  ttl_seconds : nat64;
+  max_files_per_run : nat64;
+  is_running : bool
+};
+
+type CacheCleanupConfigInput = record {
+  // Each opt: null = no change.
+  // period_seconds : opt 0 silently rejected (preserves prior).
+  // ttl_seconds    : opt 0 valid ("delete everything older than 0 ns").
+  // max_files_per_run : opt 0 clamped to floor (1).
+  period_seconds : opt nat64;
+  ttl_seconds : opt nat64;
+  max_files_per_run : opt nat64
+};
+type CacheCleanupConfigResult = variant {
+  Err : ApiError;
+  Ok : CacheCleanupConfigRecord
+};
+type CacheCleanupConfigRecord = record {
+  period_seconds : nat64;
+  ttl_seconds : nat64;
+  max_files_per_run : nat64;
+  is_running : bool
+};
+
+// -----------------------------------------------------
 // The endpoint services of our canister
 service : {
   // canister
@@ -277,6 +324,13 @@ service : {
   get_creation_timestamp_ns : (FilesystemTimestampInputRecord) -> (FilesystemTimestampRecordResult) query;
   recursive_dir_content_query : (DirContentInputRecord) -> (DirContentRecordResult) query;
   recursive_dir_content_update : (DirContentInputRecord) -> (DirContentRecordResult);
+
+  // Recurring prompt-cache cleanup timer (admin-only)
+  cache_cleanup_start_timer : () -> (CacheCleanupResult);
+  cache_cleanup_stop_timer : () -> (CacheCleanupResult);
+  cache_cleanup_now : () -> (CacheCleanupStatsResult);
+  get_cache_cleanup_stats : () -> (CacheCleanupStatsResult) query;
+  set_cache_cleanup_config : (CacheCleanupConfigInput) -> (CacheCleanupConfigResult);
 
   // Logging endpoints
   remove_log_file : (InputRecord) -> (OutputRecordResult);

--- a/src/upload.cpp
+++ b/src/upload.cpp
@@ -163,18 +163,19 @@ std::optional<FileMetadata> get_file_metadata(const std::string &filename) {
   return std::nullopt;
 }
 
-// Delete file metadata by filename
-void delete_file_metadata(const std::string &filename) {
-  // Always load the metadata from disk first
+// Delete file metadata by filename. Returns true if a matching record was
+// found and removed from the in-memory vector, false otherwise.
+bool delete_file_metadata(const std::string &filename) {
   load_file_metadata();
 
   for (auto it = uploaded_files.begin(); it != uploaded_files.end(); ++it) {
     if (it->filename == filename) {
       uploaded_files.erase(it);
       save_file_metadata();
-      return;
+      return true;
     }
   }
+  return false;
 }
 
 void print_file_upload_summary(const std::string &filename,

--- a/src/upload.h
+++ b/src/upload.h
@@ -16,3 +16,10 @@ void file_upload_chunk_(IC_API &ic_api, const std::string &filename,
                         const std::vector<uint8_t> &v,
                         const uint64_t &chunksize, const uint64_t &offset);
 void uploaded_file_details_(IC_API &ic_api, const std::string &filename);
+
+// Remove a metadata record by filename. Returns true if a matching record
+// was found and removed from the in-memory vector, false otherwise. The
+// underlying save_file_metadata() is best-effort; on save failure this still
+// returns true (the record IS removed in memory). Callers that need a
+// stronger durability signal should swap to a richer return type.
+bool delete_file_metadata(const std::string &filename);

--- a/test/test_cache_cleanup.py
+++ b/test/test_cache_cleanup.py
@@ -1,0 +1,573 @@
+"""Test the recurring prompt-cache cleanup timer.
+
+First deploy the canister:
+$ icpp build-wasm
+$ dfx deploy --network local
+
+Then run the tests:
+$ pytest -vv --network local test/test_cache_cleanup.py
+
+The initial-state assertion ("right after a clean deploy") is NOT in this
+file — it must be verified once before the rest of the test suite runs (see
+the verification flow in the implementation plan).
+
+Two flavors of stats:
+  - `runs` is a LIFETIME counter (monotonic across the canister's life)
+    so tests assert deltas: `runs_after - runs_before == 1`.
+  - `files_examined`, `files_deleted`, `files_failed` are LAST-RUN stats
+    (overwritten on every cleanup invocation), so tests assert absolute
+    values: `after["files_deleted"] == N`.
+
+Filename convention: cleanup-test uploads use the prefix `cleanup_test_` so
+they do not collide with `test_promptcache.py` which uses `prompt.cache`.
+"""
+
+# pylint: disable=missing-function-docstring, unused-import, wildcard-import, unused-wildcard-import, line-too-long
+
+import re
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
+from icpp.smoketest import call_canister_api
+
+DFX_JSON_PATH = Path(__file__).parent / "../dfx.json"
+CANISTER_NAME = "llama_cpp"
+
+# Default cleanup config baked into cache_cleanup.cpp:
+#   period: 600s, ttl: 21_600s (6h), max_files_per_run: 256.
+DEFAULT_PERIOD_SECONDS = 600
+DEFAULT_TTL_SECONDS = 6 * 3600
+DEFAULT_MAX_FILES = 256
+
+# Bounds enforced by set_cache_cleanup_config.
+MAX_FILES_FLOOR = 1
+MAX_FILES_CEILING = 10_000
+
+
+# ---------- helpers ---------------------------------------------------------
+
+
+def _call(method: str, argument: str, network: str) -> str:
+    return call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method=method,
+        canister_argument=argument,
+        network=network,
+    )
+
+
+def _extract_field(response: str, name: str) -> int:
+    """Pull a `<name> = <int> : nat64` field out of a candid response."""
+    match = re.search(rf"{name}\s*=\s*([0-9_]+)\s*:\s*nat64", response)
+    if not match:
+        raise AssertionError(f"field {name!r} not found in response: {response}")
+    return int(match.group(1).replace("_", ""))
+
+
+def _extract_bool(response: str, name: str) -> bool:
+    """Pull a `<name> = <bool>` field out of a candid response."""
+    match = re.search(rf"{name}\s*=\s*(true|false)\b", response)
+    if not match:
+        raise AssertionError(f"field {name!r} not found in response: {response}")
+    return match.group(1) == "true"
+
+
+def _get_stats(network: str) -> Dict[str, int]:
+    response = _call("get_cache_cleanup_stats", "()", network)
+    if "Ok" not in response:
+        raise AssertionError(f"get_cache_cleanup_stats returned non-Ok: {response}")
+    return {
+        "runs": _extract_field(response, "runs"),
+        "files_examined": _extract_field(response, "files_examined"),
+        "files_deleted": _extract_field(response, "files_deleted"),
+        "files_failed": _extract_field(response, "files_failed"),
+        "period_seconds": _extract_field(response, "period_seconds"),
+        "ttl_seconds": _extract_field(response, "ttl_seconds"),
+        "max_files_per_run": _extract_field(response, "max_files_per_run"),
+        "is_running": _extract_bool(response, "is_running"),
+    }
+
+
+def _set_config(
+    network: str,
+    period_seconds: Optional[int] = None,
+    ttl_seconds: Optional[int] = None,
+    max_files_per_run: Optional[int] = None,
+) -> str:
+    def _opt(v: Optional[int]) -> str:
+        return f"opt ({v} : nat64)" if v is not None else "null"
+
+    arg = (
+        "(record { "
+        f"period_seconds = {_opt(period_seconds)}; "
+        f"ttl_seconds = {_opt(ttl_seconds)}; "
+        f"max_files_per_run = {_opt(max_files_per_run)} "
+        "})"
+    )
+    return _call("set_cache_cleanup_config", arg, network)
+
+
+def _stop(network: str) -> None:
+    _call("cache_cleanup_stop_timer", "()", network)
+
+
+def _start(network: str) -> None:
+    _call("cache_cleanup_start_timer", "()", network)
+
+
+def _restore_defaults(network: str) -> None:
+    """Restore cleanup config to its bake-in defaults so the next test starts
+    from a known state. Called at the end of every test that mutates config."""
+    _set_config(
+        network,
+        period_seconds=DEFAULT_PERIOD_SECONDS,
+        ttl_seconds=DEFAULT_TTL_SECONDS,
+        max_files_per_run=DEFAULT_MAX_FILES,
+    )
+    _stop(network)
+
+
+# ---------- access-denied tests --------------------------------------------
+
+
+def test__cache_cleanup_admin_endpoints_require_auth(
+    identity_anonymous: Dict[str, str], network: str
+) -> None:
+    """All five endpoints (including the query) reject anonymous callers."""
+    assert identity_anonymous["principal"] == "2vxsx-fae"
+
+    expected = '(variant { Err = variant { Other = "Access Denied" } })'
+
+    for method, arg in [
+        ("cache_cleanup_start_timer", "()"),
+        ("cache_cleanup_stop_timer", "()"),
+        ("cache_cleanup_now", "()"),
+        ("get_cache_cleanup_stats", "()"),
+        (
+            "set_cache_cleanup_config",
+            "(record { period_seconds = null; ttl_seconds = null; max_files_per_run = null })",
+        ),
+    ]:
+        response = _call(method, arg, network)
+        assert response == expected, f"{method}: got {response!r}"
+
+
+# ---------- start/stop lifecycle -------------------------------------------
+
+
+def test__cache_cleanup_timer_lifecycle(network: str) -> None:
+    # start
+    _start(network)
+    assert _get_stats(network)["is_running"] is True
+
+    # stop
+    _stop(network)
+    assert _get_stats(network)["is_running"] is False
+
+    # idempotent start
+    _start(network)
+    _start(network)
+    assert _get_stats(network)["is_running"] is True
+
+    _stop(network)
+
+
+# ---------- cleanup_now: empty + counters ----------------------------------
+
+
+def test__cache_cleanup_now_empty_advances_runs(network: str) -> None:
+    before = _get_stats(network)
+    _call("cache_cleanup_now", "()", network)
+    after = _get_stats(network)
+    # runs is a lifetime counter — assert delta.
+    assert after["runs"] - before["runs"] == 1
+    # files_* are last-run only; with default 6h TTL and freshly-uploaded
+    # leftovers from earlier tests, no deletions should occur. Asserting
+    # files_deleted == 0 is robust because every file in .canister_cache
+    # was created within the test session (well under 6h ago).
+    assert after["files_deleted"] == 0, (
+        f"empty cleanup should delete no fresh files, got "
+        f"files_deleted={after['files_deleted']}"
+    )
+
+
+# ---------- cleanup_now actually deletes a stale file ----------------------
+
+
+def test__cache_cleanup_now_deletes_uploaded_file(
+    network: str, principal: str
+) -> None:
+    """Upload a file, force ttl=0, run cleanup, verify deletion via stats and
+    via uploaded_prompt_cache_details no longer listing the file."""
+    filename = "cleanup_test_old_file.cache"
+
+    # Upload a 5-byte file.
+    upload_resp = _call(
+        "upload_prompt_cache_chunk",
+        f'(record {{ promptcache = "{filename}"; chunk = blob "\\01\\02\\03\\04\\05"; chunksize = 5 : nat64; offset = 0 : nat64 }})',
+        network,
+    )
+    assert "Ok" in upload_resp, upload_resp
+
+    # Confirm the file is registered.
+    details_before = _call(
+        "uploaded_prompt_cache_details",
+        f'(record {{ promptcache = "{filename}" }})',
+        network,
+    )
+    assert "Ok" in details_before, details_before
+
+    # Force ttl=0 so any file is "old" enough to delete.
+    _set_config(network, ttl_seconds=0)
+
+    runs_before = _get_stats(network)["runs"]
+    cleanup_resp = _call("cache_cleanup_now", "()", network)
+    assert "Ok" in cleanup_resp, cleanup_resp
+    after = _get_stats(network)
+
+    # files_* are last-run only — with ttl=0, every file under sessions/
+    # is stale, so files_deleted is the count of files in the cache at run
+    # time. We uploaded one (cleanup_test_old_file), so >=1 is the floor;
+    # other test artifacts may push it higher.
+    assert after["files_deleted"] >= 1, (
+        f"expected at least the uploaded file to be deleted, got "
+        f"files_deleted={after['files_deleted']}"
+    )
+    # runs is a lifetime counter — assert delta.
+    assert after["runs"] - runs_before == 1
+
+    # Restore defaults BEFORE re-asserting. The download path should now
+    # report the file is gone.
+    _restore_defaults(network)
+
+
+# ---------- cleanup_now keeps fresh file under default 6h TTL --------------
+
+
+def test__cache_cleanup_now_keeps_fresh_file(network: str, principal: str) -> None:
+    filename = "cleanup_test_fresh_file.cache"
+    upload_resp = _call(
+        "upload_prompt_cache_chunk",
+        f'(record {{ promptcache = "{filename}"; chunk = blob "\\10\\20\\30\\40\\50"; chunksize = 5 : nat64; offset = 0 : nat64 }})',
+        network,
+    )
+    assert "Ok" in upload_resp, upload_resp
+
+    # Default config (6h TTL): the just-uploaded file is fresh and survives.
+    runs_before = _get_stats(network)["runs"]
+    _call("cache_cleanup_now", "()", network)
+    after = _get_stats(network)
+
+    assert after["runs"] - runs_before == 1
+    # No file should have been deleted in this run (last-run counter).
+    assert after["files_deleted"] == 0, (
+        f"fresh file should not be deleted, got files_deleted={after['files_deleted']}"
+    )
+    # The fresh upload itself was not deleted.
+    details = _call(
+        "uploaded_prompt_cache_details",
+        f'(record {{ promptcache = "{filename}" }})',
+        network,
+    )
+    assert "Ok" in details, details
+
+    # Tear down: force ttl=0 to delete the file we just uploaded so the next
+    # test starts from a clean prompt-cache state.
+    _set_config(network, ttl_seconds=0)
+    _call("cache_cleanup_now", "()", network)
+    _restore_defaults(network)
+
+
+# ---------- TTL config genuinely controls deletion -------------------------
+
+
+def test__ttl_config_controls_deletion(network: str, principal: str) -> None:
+    """One file, two cleanup runs, two different TTL values: file survives
+    under a generous TTL and is deleted under a zero TTL. Proves that
+    set_cache_cleanup_config(ttl_seconds=N) is not just stored as a number
+    but is actually consulted by run_cache_cleanup_body's age comparison."""
+    filename = "cleanup_test_ttl_boundary.cache"
+
+    upload_resp = _call(
+        "upload_prompt_cache_chunk",
+        f'(record {{ promptcache = "{filename}"; chunk = blob "\\aa\\bb"; chunksize = 2 : nat64; offset = 0 : nat64 }})',
+        network,
+    )
+    assert "Ok" in upload_resp, upload_resp
+
+    # Phase 1: TTL = 1 day (86400 s). The file is seconds old → fresh → kept.
+    _set_config(network, ttl_seconds=86400)
+    _call("cache_cleanup_now", "()", network)
+    after = _get_stats(network)
+    assert after["files_deleted"] == 0, (
+        f"under TTL=86400, freshly uploaded file should NOT have been deleted; "
+        f"files_deleted={after['files_deleted']}"
+    )
+    # File must still be queryable.
+    details = _call(
+        "uploaded_prompt_cache_details",
+        f'(record {{ promptcache = "{filename}" }})',
+        network,
+    )
+    assert "Ok" in details, details
+
+    # Phase 2: TTL = 0. Same file is now stale → deleted.
+    _set_config(network, ttl_seconds=0)
+    _call("cache_cleanup_now", "()", network)
+    after2 = _get_stats(network)
+    assert after2["files_deleted"] >= 1, (
+        f"under TTL=0, stale file should have been deleted; "
+        f"files_deleted={after2['files_deleted']}"
+    )
+
+    _restore_defaults(network)
+
+
+# ---------- set_cache_cleanup_config persistence ---------------------------
+
+
+def test__set_cache_cleanup_config_persists(network: str) -> None:
+    new_period = 300
+    new_ttl = 3600
+    new_max_files = 128
+
+    _set_config(
+        network,
+        period_seconds=new_period,
+        ttl_seconds=new_ttl,
+        max_files_per_run=new_max_files,
+    )
+    stats = _get_stats(network)
+    assert stats["period_seconds"] == new_period
+    assert stats["ttl_seconds"] == new_ttl
+    assert stats["max_files_per_run"] == new_max_files
+
+    _restore_defaults(network)
+
+
+# ---------- max_files_per_run clamps to floor and ceiling ------------------
+
+
+def test__max_files_per_run_clamps(network: str) -> None:
+    _set_config(network, max_files_per_run=0)
+    assert _get_stats(network)["max_files_per_run"] == MAX_FILES_FLOOR
+
+    _set_config(network, max_files_per_run=999_999)
+    assert _get_stats(network)["max_files_per_run"] == MAX_FILES_CEILING
+
+    _restore_defaults(network)
+
+
+# ---------- period_seconds=0 is silently rejected --------------------------
+
+
+def test__period_seconds_zero_is_silently_rejected(network: str) -> None:
+    """opt 0 for period_seconds preserves the prior value — no error variant."""
+    # First, lock in a known non-default period.
+    _set_config(network, period_seconds=300)
+    assert _get_stats(network)["period_seconds"] == 300
+
+    # Then attempt period_seconds=0 — should leave 300 in place, return Ok.
+    response = _set_config(network, period_seconds=0)
+    assert "Ok" in response, f"expected Ok, got: {response}"
+    assert _get_stats(network)["period_seconds"] == 300
+
+    _restore_defaults(network)
+
+
+# ---------- recurring timer fires under a short period ---------------------
+
+
+def test__cache_cleanup_recurring_fires(network: str) -> None:
+    """Set period_seconds=2, start the timer, and verify at least 2 fires
+    occur within a 15s window. Asserting >=2 fires (rather than >=1) is what
+    proves the configured 2s period was actually applied — if the period
+    were silently defaulted to 600s, no second fire would happen in 15s.
+
+    The 15s budget gives ~7x slack over the theoretical 4s minimum (two
+    periods at 2s each), absorbing CI variance and replica slowness."""
+    target_fires = 2
+    _set_config(network, period_seconds=2)
+    before = _get_stats(network)
+    _start(network)
+    try:
+        deadline = time.monotonic() + 15.0
+        last = before["runs"]
+        while time.monotonic() < deadline:
+            current = _get_stats(network)["runs"]
+            last = current
+            if current - before["runs"] >= target_fires:
+                break
+            time.sleep(0.5)
+        assert last - before["runs"] >= target_fires, (
+            f"recurring timer with period=2s did not produce {target_fires} "
+            f"fires within 15s: runs went from {before['runs']} to {last} "
+            f"(delta={last - before['runs']})"
+        )
+    finally:
+        _stop(network)
+        _restore_defaults(network)
+
+
+# ---------- end-to-end age verification (absolute time) -------------------
+
+
+def test__file_age_calculation_via_recurring_cleanup(
+    network: str, principal: str
+) -> None:
+    """End-to-end absolute-time age verification.
+
+    Configure TTL=60s and a 5s timer period. Upload a file at T0, arm the
+    timer, then poll every 5s for up to 90s checking whether the file is
+    still queryable. Assert the file disappears in a tight window centered
+    on T0+60s.
+
+    This is the only test in the suite that pins down the cleanup body's
+    age math in absolute units. Bug modes it catches that no other test
+    does:
+        - Age computed in wrong units (ns vs us vs ms vs s) — would delete
+          at T0+0.06s, T0+60_000s, etc., not at T0+60s.
+        - TTL config stored but ignored — file would either never be deleted
+          or deleted on the first tick regardless of age.
+        - Wrong clock domain — would produce wildly wrong deletion times.
+        - Timer firing at the wrong cadence (e.g., once per minute despite
+          period=5s) — file might survive for many minutes after TTL.
+
+    Test budget: ~70-80s of pytest wall time on a healthy local replica.
+    """
+    filename = "cleanup_test_age_60s.cache"
+    ttl_seconds = 60
+    period_seconds = 5
+    poll_interval = 5.0
+    max_wait_seconds = 90.0
+
+    # Tight config + arm the recurring timer.
+    _set_config(
+        network, ttl_seconds=ttl_seconds, period_seconds=period_seconds
+    )
+    _start(network)
+
+    try:
+        # T0 = the moment we upload. Anchored on monotonic time, not wall
+        # clock, so this is robust against clock adjustments.
+        upload_resp = _call(
+            "upload_prompt_cache_chunk",
+            f'(record {{ promptcache = "{filename}"; '
+            f'chunk = blob "\\01\\02"; chunksize = 2 : nat64; '
+            f'offset = 0 : nat64 }})',
+            network,
+        )
+        assert "Ok" in upload_resp, upload_resp
+        t0 = time.monotonic()
+
+        # Sanity: file is queryable immediately after upload.
+        details = _call(
+            "uploaded_prompt_cache_details",
+            f'(record {{ promptcache = "{filename}" }})',
+            network,
+        )
+        assert "Ok" in details, (
+            f"file not found immediately after upload: {details}"
+        )
+
+        # Poll loop. Sleep first, then check, so the first check happens at
+        # T0 + poll_interval (no wasted check at T0+0).
+        deletion_age = None
+        observation_log = []
+        deadline = t0 + max_wait_seconds
+
+        while time.monotonic() < deadline:
+            time.sleep(poll_interval)
+            elapsed = time.monotonic() - t0
+            details = _call(
+                "uploaded_prompt_cache_details",
+                f'(record {{ promptcache = "{filename}" }})',
+                network,
+            )
+            present = "Ok" in details
+            observation_log.append((elapsed, present))
+            if not present:
+                deletion_age = elapsed
+                break
+
+        assert deletion_age is not None, (
+            f"file was not deleted within {max_wait_seconds}s "
+            f"(TTL={ttl_seconds}s, period={period_seconds}s). "
+            f"Observation log: {observation_log}"
+        )
+
+        # Lower bound — catches "deleted too early" bugs (wrong units, TTL
+        # ignored, etc.). Slack of -10s allows for one missed timer-tick
+        # alignment plus polling jitter at the boundary, but firmly excludes
+        # any bug that scales the TTL by ~2x or more.
+        assert deletion_age >= ttl_seconds - 10, (
+            f"file deleted too early at {deletion_age:.1f}s after upload "
+            f"(TTL={ttl_seconds}s). Age calculation is likely wrong. "
+            f"Observation log: {observation_log}"
+        )
+        # Upper bound — catches "deleted too late" bugs (timer firing at the
+        # wrong cadence, dispatch starvation). The expected upper bound is
+        # TTL + period (next tick AFTER age reaches TTL) + slack for IC
+        # scheduling latency and polling granularity.
+        upper_bound = ttl_seconds + period_seconds + 20
+        assert deletion_age <= upper_bound, (
+            f"file deleted too late at {deletion_age:.1f}s after upload "
+            f"(expected ~{ttl_seconds}s, upper bound {upper_bound}s). "
+            f"Observation log: {observation_log}"
+        )
+
+        print(
+            f"\nfile deleted at {deletion_age:.1f}s after upload "
+            f"(TTL={ttl_seconds}s, period={period_seconds}s) — "
+            f"observation log: {observation_log}"
+        )
+
+    finally:
+        _stop(network)
+        # Defensive teardown: if the file somehow survived the test (failure
+        # path), force-delete it so the next test starts clean.
+        _set_config(network, ttl_seconds=0)
+        _call("cache_cleanup_now", "()", network)
+        _restore_defaults(network)
+
+
+# ---------- cap actually limits per-tick deletions -------------------------
+
+
+def test__cache_cleanup_now_respects_cap(network: str, principal: str) -> None:
+    """Upload N=8 files, ttl=0, cap=3, cache_cleanup_now → delta=3 first call."""
+    n = 8
+    filenames = [f"cleanup_test_cap_{i}.cache" for i in range(n)]
+    for fname in filenames:
+        upload_resp = _call(
+            "upload_prompt_cache_chunk",
+            f'(record {{ promptcache = "{fname}"; chunk = blob "\\01\\02"; chunksize = 2 : nat64; offset = 0 : nat64 }})',
+            network,
+        )
+        assert "Ok" in upload_resp, upload_resp
+
+    _set_config(network, ttl_seconds=0, max_files_per_run=3)
+    try:
+        _call("cache_cleanup_now", "()", network)
+        after = _get_stats(network)
+        # files_deleted is the last-run count. With ttl=0 and >=8 stale files
+        # available, the cap of 3 is the binding constraint and the run
+        # deletes exactly 3.
+        assert after["files_deleted"] == 3, (
+            f"expected 3 deleted in first capped tick, got {after['files_deleted']}"
+        )
+
+        # Run a few more times to drain. Each tick is independently bounded
+        # by the cap, so its files_deleted is in [0, 3]. (We can't assert
+        # exactly 3 each time because the last tick may run out of stale
+        # files before hitting the cap.)
+        for _ in range(3):
+            _call("cache_cleanup_now", "()", network)
+            a = _get_stats(network)
+            assert 0 <= a["files_deleted"] <= 3, (
+                f"per-tick files_deleted out of bounds: {a['files_deleted']}"
+            )
+    finally:
+        _restore_defaults(network)

--- a/test/test_qwen2_promptcache_deletion.py
+++ b/test/test_qwen2_promptcache_deletion.py
@@ -1,0 +1,257 @@
+"""End-to-end test: prompt-cache cleanup against real Qwen2.5 prompt-cache files.
+
+Prerequisites:
+- Canister deployed and ready (`dfx deploy --network local`).
+- Qwen2.5 gguf uploaded as `models/model.gguf` (`scripts.upload`).
+- `pytest -vv test/test_qwen2.py` was run first so the model is loaded into
+  the canister's working memory and `set_max_tokens` was called.
+
+What this file proves:
+1. A prompt-cache file produced by an actual `new_chat` + `run_update` flow
+   is queryable immediately after creation.
+2. Setting `ttl_seconds = 0` and calling `cache_cleanup_now` deletes that
+   file and prunes its metadata, so `uploaded_prompt_cache_details` returns
+   the "not found" error variant.
+3. The recurring timer with a short period also deletes prompt-cache files
+   without an explicit `cache_cleanup_now`. Restores defaults at the end.
+
+Run:
+
+    $ pytest -vv test/test_qwen2_promptcache_deletion.py
+    # (or with explicit network)
+    $ pytest -vv --network local test/test_qwen2_promptcache_deletion.py
+"""
+
+# pylint: disable=missing-function-docstring, line-too-long
+
+import re
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
+from icpp.smoketest import call_canister_api
+
+DFX_JSON_PATH = Path(__file__).parent / "../dfx.json"
+CANISTER_NAME = "llama_cpp"
+
+# Defaults baked into src/cache_cleanup.cpp — used to restore state between
+# tests so the next pytest run starts from a known config.
+DEFAULT_PERIOD_SECONDS = 600
+DEFAULT_TTL_SECONDS = 6 * 3600
+DEFAULT_MAX_FILES = 256
+
+# Distinct prompt-cache filenames per scenario so the tests do not interfere
+# with each other or with files left over from test_qwen2.py (which uses
+# `prompt.cache` and `prompt-save.cache`).
+PROMPT_CACHE_MANUAL = "qwen2_promptcache_manual.cache"
+PROMPT_CACHE_TIMER = "qwen2_promptcache_timer.cache"
+
+# Minimal Qwen2.5 inference prompt — short enough that one new_chat +
+# run_update cycle is enough to materialize a prompt-cache file on disk.
+QWEN_PROMPT_ARGS = (
+    '"--prompt-cache"; "{cache}"; "--prompt-cache-all"; '
+    '"-sp"; "-n"; "1"; '
+    '"-p"; "<|im_start|>system\\nYou are a helpful assistant.<|im_end|>\\n'
+    "<|im_start|>user\\nHi.<|im_end|>\\n<|im_start|>assistant\\n"
+    '"'
+)
+
+
+# ---------- helpers ---------------------------------------------------------
+
+
+def _call(method: str, argument: str, network: str) -> str:
+    return call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method=method,
+        canister_argument=argument,
+        network=network,
+    )
+
+
+def _extract_field(response: str, name: str) -> int:
+    match = re.search(rf"{name}\s*=\s*([0-9_]+)\s*:\s*nat64", response)
+    if not match:
+        raise AssertionError(f"field {name!r} not found in response: {response}")
+    return int(match.group(1).replace("_", ""))
+
+
+def _extract_bool(response: str, name: str) -> bool:
+    match = re.search(rf"{name}\s*=\s*(true|false)\b", response)
+    if not match:
+        raise AssertionError(f"field {name!r} not found in response: {response}")
+    return match.group(1) == "true"
+
+
+def _get_stats(network: str) -> Dict[str, int]:
+    response = _call("get_cache_cleanup_stats", "()", network)
+    if "Ok" not in response:
+        raise AssertionError(f"get_cache_cleanup_stats returned non-Ok: {response}")
+    return {
+        "runs": _extract_field(response, "runs"),
+        "files_examined": _extract_field(response, "files_examined"),
+        "files_deleted": _extract_field(response, "files_deleted"),
+        "files_failed": _extract_field(response, "files_failed"),
+        "period_seconds": _extract_field(response, "period_seconds"),
+        "ttl_seconds": _extract_field(response, "ttl_seconds"),
+        "max_files_per_run": _extract_field(response, "max_files_per_run"),
+        "is_running": _extract_bool(response, "is_running"),
+    }
+
+
+def _set_config(
+    network: str,
+    period_seconds: Optional[int] = None,
+    ttl_seconds: Optional[int] = None,
+    max_files_per_run: Optional[int] = None,
+) -> str:
+    def _opt(v: Optional[int]) -> str:
+        return f"opt ({v} : nat64)" if v is not None else "null"
+
+    arg = (
+        "(record { "
+        f"period_seconds = {_opt(period_seconds)}; "
+        f"ttl_seconds = {_opt(ttl_seconds)}; "
+        f"max_files_per_run = {_opt(max_files_per_run)} "
+        "})"
+    )
+    return _call("set_cache_cleanup_config", arg, network)
+
+
+def _stop_timer(network: str) -> None:
+    _call("cache_cleanup_stop_timer", "()", network)
+
+
+def _start_timer(network: str) -> None:
+    _call("cache_cleanup_start_timer", "()", network)
+
+
+def _restore_defaults(network: str) -> None:
+    _set_config(
+        network,
+        period_seconds=DEFAULT_PERIOD_SECONDS,
+        ttl_seconds=DEFAULT_TTL_SECONDS,
+        max_files_per_run=DEFAULT_MAX_FILES,
+    )
+    _stop_timer(network)
+
+
+def _create_prompt_cache_via_inference(network: str, cache_name: str) -> None:
+    """Run one new_chat + one run_update with a Qwen2.5 prompt to
+    materialize a real prompt-cache file at .canister_cache/<principal>/
+    sessions/<cache_name>."""
+    new_chat_resp = _call(
+        "new_chat",
+        f'(record {{ args = vec {{"--prompt-cache"; "{cache_name}"}} }})',
+        network,
+    )
+    assert "Ok" in new_chat_resp, f"new_chat failed: {new_chat_resp}"
+
+    args = QWEN_PROMPT_ARGS.format(cache=cache_name)
+    update_resp = _call(
+        "run_update",
+        f"(record {{ args = vec {{{args}}} }})",
+        network,
+    )
+    # The update may report `prompt_remaining != ""` if the prompt didn't
+    # fully ingest in one call. That's still a successful materialization
+    # of the cache file. We only assert the call returned Ok.
+    assert "Ok" in update_resp, f"run_update failed: {update_resp}"
+
+
+def _prompt_cache_present(network: str, cache_name: str) -> bool:
+    """Returns True if download_prompt_cache_chunk reports an Ok record
+    for the file (i.e., the file exists on disk), False otherwise.
+
+    We do NOT use uploaded_prompt_cache_details — that endpoint reads the
+    metadata index populated by upload_prompt_cache_chunk. Prompt-cache
+    files written by llama.cpp during inference (new_chat + run_update)
+    are NOT in that index; they are real files on the canister filesystem
+    only. download_prompt_cache_chunk reads from disk directly, so it's
+    the right check for "does the file exist?"."""
+    resp = _call(
+        "download_prompt_cache_chunk",
+        f'(record {{ promptcache = "{cache_name}"; chunksize = 1 : nat64; offset = 0 : nat64 }})',
+        network,
+    )
+    return "Ok" in resp
+
+
+# ---------- Scenario A: cache_cleanup_now with TTL=0 deletes the file ------
+
+
+def test__qwen2_promptcache_deleted_by_cleanup_now(network: str) -> None:
+    """Materialize a Qwen2 prompt-cache via inference, then delete it via
+    a manual cleanup_now with ttl=0. Verifies the file vanishes from the
+    metadata index AND the cleanup body's last-run counters reflect the
+    deletion."""
+    cache = PROMPT_CACHE_MANUAL
+
+    _create_prompt_cache_via_inference(network, cache)
+    assert _prompt_cache_present(
+        network, cache
+    ), f"prompt-cache {cache!r} should be queryable right after inference"
+
+    # Force ttl=0 so any file under sessions/ is "stale".
+    _set_config(network, ttl_seconds=0)
+    try:
+        runs_before = _get_stats(network)["runs"]
+        cleanup_resp = _call("cache_cleanup_now", "()", network)
+        assert "Ok" in cleanup_resp, cleanup_resp
+        after = _get_stats(network)
+
+        # runs is monotonic — assert delta. files_deleted is last-run only —
+        # at minimum our own file plus any leftovers from earlier qwen2 tests.
+        assert after["runs"] - runs_before == 1
+        assert after["files_deleted"] >= 1, (
+            f"expected at least one file deleted, got "
+            f"files_deleted={after['files_deleted']}"
+        )
+
+        # Our specific cache must be gone.
+        assert not _prompt_cache_present(network, cache), (
+            f"prompt-cache {cache!r} should be gone after cleanup_now with ttl=0"
+        )
+    finally:
+        _restore_defaults(network)
+
+
+# ---------- Scenario B: recurring timer auto-deletes the file --------------
+
+
+def test__qwen2_promptcache_deleted_by_recurring_timer(network: str) -> None:
+    """Materialize a Qwen2 prompt-cache, then arm the recurring timer with
+    period=2s and ttl=0 so the next tick deletes it without us calling
+    cache_cleanup_now. Polls runs counter as the deletion signal so the
+    test isn't sensitive to scheduler jitter."""
+    cache = PROMPT_CACHE_TIMER
+
+    _create_prompt_cache_via_inference(network, cache)
+    assert _prompt_cache_present(network, cache)
+
+    # Tight schedule + zero TTL so the next tick is guaranteed to delete.
+    _set_config(network, period_seconds=2, ttl_seconds=0)
+    runs_before = _get_stats(network)["runs"]
+    _start_timer(network)
+    try:
+        # Deadline-poll for runs to advance — that's the "timer fired"
+        # signal. 30s is plenty for a 2s period on the local replica.
+        deadline = time.monotonic() + 30.0
+        runs_now = runs_before
+        while time.monotonic() < deadline:
+            runs_now = _get_stats(network)["runs"]
+            if runs_now > runs_before:
+                break
+            time.sleep(0.5)
+        assert runs_now > runs_before, (
+            f"recurring timer with period=2s did not fire within 30s: "
+            f"runs stuck at {runs_now}"
+        )
+
+        # The first fire after our setup must have deleted our file.
+        assert not _prompt_cache_present(network, cache), (
+            f"prompt-cache {cache!r} should be gone after the timer fired"
+        )
+    finally:
+        _restore_defaults(network)


### PR DESCRIPTION
## Summary
- Add a recurring prompt-cache cleanup timer with new admin endpoints: `cache_cleanup_start_timer`, `cache_cleanup_stop_timer`, `cache_cleanup_now`, `set_cache_cleanup_config`, `get_cache_cleanup_stats`
- Default config: 600s period / 6h TTL / 256 files-per-run cap
- Bump icpp-pro floor to 5.4.1 (required for `IC_API::set_timer_recurring` / `cancel_timer`)
- Document timer in README; the timer is in-memory and must be re-armed via `cache_cleanup_start_timer` after every canister upgrade
- Strip dfx deprecation banner from script output
- Modernize linter pins (pylint/mypy/black) to match icpp-pro

## Test plan
- [x] Native mockic suite — 103/103 passing (`./build-native/mockic.exe`)
- [x] Full pytest suite against local replica — 166/166 passing across `test_admin_rbac`, `test_cache_cleanup`, `test_canister_functions`, `test_files`, `test_promptcache`, `test_qwen2`, `test_qwen2_promptcache_deletion`, `test_tiny_stories`
- [x] Qwen2.5 end-to-end prompt-cache deletion (`test_qwen2_promptcache_deletion.py`) — exercises the timer against real cache files