### PR TITLE
Add hourly cycle-balance monitor with admin-gated get_cycle_balance query

### DIFF
--- a/.claude/skills/new-feature-development/SKILL.md
+++ b/.claude/skills/new-feature-development/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: new-feature-development
+description: End-to-end lifecycle for adding a new capability to llama_cpp_canister — design, implement, test, document, and verify with no regressions
+disable-model-invocation: false
+user-invocable: true
+allowed-tools: Bash, Read, Edit, Write, AskUserQuestion
+---
+
+# New Feature Development for llama_cpp_canister
+
+A repeatable lifecycle for adding a new capability (endpoint, timer, config,
+etc.) to the canister. It generalizes the project's "Workflow for Adding
+Security Fixes" (see `CLAUDE.md`). Follow the steps in order; **reuse existing
+patterns** rather than inventing new ones.
+
+The recurring cycle-balance monitor (`src/cycle_balance.{h,cpp}`,
+`native/test_cycle_balance.cpp`, `test/test_cycle_balance.py`) is a reference
+example that was built with exactly this lifecycle — copy its shape.
+
+## 1. Explore precedents first
+
+Before writing anything, find the closest existing feature and copy its
+structure. Known good templates in this repo:
+
+- **Recurring timer** → `src/cache_cleanup.{h,cpp}` (start/stop, idempotent
+  re-arm, worker that does NOT construct its own `IC_API`) and
+  `src/cycle_balance.{h,cpp}`.
+- **Admin RBAC gating** → `src/auth.h`: `has_admin_query_role` /
+  `has_admin_update_role` (+ `*_or_whitelisted` for user-facing endpoints) and
+  `send_access_denied_api_error`.
+- **Simple endpoints** → `src/health.cpp`, `src/whoami.cpp`,
+  `src/max_tokens.cpp`.
+- **Persistent state** → plain `static` / global C++ variables (orthogonal
+  persistence; see `src/auth.cpp`, `src/max_tokens.cpp`). Note: timer state and
+  plain globals are wiped on upgrade unless intentionally persisted.
+
+Use the `Explore` subagent to locate the right precedent if unsure.
+
+## 2. Clarify requirements with the user
+
+Resolve open design questions BEFORE coding (use `AskUserQuestion`):
+- Lifecycle: operator-driven start endpoint vs auto-start? (This repo has no
+  `canister_post_upgrade`; existing timers are operator-driven.)
+- Return shape and error behavior (e.g. what to return when a feature is "off").
+- Naming convention (most endpoints are snake_case; RBAC ones are camelCase).
+
+## 3. Create a feature branch
+
+```bash
+git checkout -b feature/<name>   # off main
+```
+
+## 4. Implement
+
+- New `src/<feature>.{h,cpp}`. Each endpoint is a free function whose name
+  matches the `.did` method; export it via `WASM_SYMBOL_EXPORTED("canister_query <name>")`
+  or `"canister_update <name>"` in the header.
+- First line of every endpoint: `IC_API ic_api(CanisterQuery{std::string(__func__)}, false);`
+  (or `CanisterUpdate`). Gate sensitive endpoints with the `has_admin_*` helpers
+  and `send_access_denied_api_error`.
+- Timer callbacks run inside `canister_global_timer`'s `IC_API` frame and MUST
+  NOT construct their own `IC_API` — call raw `ic0.h` imports for system calls,
+  and `IC_API::time()` (static) for time.
+- Add types + service methods to `src/llama_cpp.did`. Reuse existing result
+  types (`ApiError`, `StatusCodeRecordResult`) where they fit.
+- `icpp.toml` auto-globs `src/*.cpp` and `native/*.cpp` — no build-config edit
+  needed for new files.
+
+## 5. Test
+
+- **Native MockIC**: `native/test_<feature>.{cpp,h}`; wire `#include` + call
+  into `native/main.cpp`. For expected Candid hex of error variants, reuse the
+  ACTUAL C++ output (the type-table ordering differs from `didc`'s — see the
+  `ACCESS_DENIED_API_ERROR` constant). Tip: the MockIC seeds a deterministic
+  cycle balance of 3'000'000'000'000 and lets you pin time with
+  `ic0mock_set_time_override`.
+- **pytest smoke**: `test/test_<feature>.py`; add it to the `test_paths` list in
+  `scripts/qa_deploy_and_pytest.py` so it runs in the full QA scenario. Match
+  the exact response format the framework returns — e.g. a status record prints
+  as `{ status_code = 200 : nat16;}` (trailing `;}`, no space).
+- Clean `.canister_cache` between repeated native runs — leftover files make
+  filesystem-touching tests (e.g. cache_cleanup) non-deterministic.
+
+## 6. Document
+
+Add a README section explaining what the feature does, its operator-driven
+lifecycle, the required admin roles, and copy-pasteable `dfx canister call`
+examples (including any "off"/error responses).
+
+## 7. Verify — targeted
+
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda activate llama_cpp_canister
+
+# Format the new files with the repo's clang-format:
+"$HOME/.icpp/wasi-sdk/wasi-sdk-25.0/bin/clang-format" --style=file -i src/<feature>.* native/test_<feature>.*
+
+# Native unit tests:
+icpp build-native && ./build-native/mockic.exe
+
+# WASM build + local deploy (regenerates declarations):
+icpp build-wasm
+dfx start --clean --background
+dfx deploy --network local
+
+# Exercise the new endpoints:
+dfx canister --network local call llama_cpp <new_endpoint> '()'
+
+# New smoke tests:
+pytest -vv --network local test/test_<feature>.py
+```
+
+## 8. Verify — full regression
+
+```bash
+make all-static   # cpp-format + python format/lint/type
+make test-llm-native   # native MockIC
+make test-llm-wasm     # qa_deploy_and_pytest (deploys tiny model, runs pytest suites)
+# or all three at once:
+make all-tests
+```
+`make all-tests` should end with "Congratulations, everything passed!".
+
+Note: `make test-llm-wasm` (and the qwen2 walkthrough below) require
+`python -m scripts.upload` to load a model. If that step fails with
+`404 .../api/v3/.../query` (an icp_core agent vs dfx replica mismatch), the
+upload tooling is broken in your environment — the model-dependent suites can't
+run until it's fixed. The native, static, and dfx-based smoke suites
+(`call_canister_api` shells out to dfx, so they still work) remain valid.
+
+## 9. Verify — full README walkthrough
+
+Deploy the qwen2 model following the exact README "Getting Started" steps
+(download → deploy → fabricate-cycles → upload+verify sha256 → load_model →
+set_max_tokens → new_chat → run_update until `generated_eog = true`), then
+exercise the new feature on the live, model-loaded canister. Confirms no
+regression in the inference path. Also run:
+```bash
+pytest -vv --network local test/test_canister_functions.py
+pytest -vv --network local test/test_qwen2.py
+```
+
+## 10. Commit
+
+Per `CLAUDE.md`: single-line commit message, no `Co-Authored-By` trailer, no
+self-attribution, never `--no-verify`.
+
+```bash
+git add -A && git commit -m "<concise single-line summary>"
+```

--- a/README.md
+++ b/README.md
@@ -709,6 +709,47 @@ dfx canister call llama_cpp set_cache_cleanup_config '(record {
 })'
 ```
 
+# Cycle Balance Monitoring
+
+The canister can track its own cycle balance on a recurring schedule. An
+hourly timer refreshes a cached snapshot of the balance (via the IC's
+`canister_cycle_balance128` system call), which admins read cheaply through
+the `get_cycle_balance` query — no need for a live system call on every check.
+
+**Defaults:**
+- period: 3600 seconds (refreshed once per hour)
+
+**Operator-driven lifecycle.** The timer is **not** auto-armed in
+`canister_init` or `canister_post_upgrade`. After every install / upgrade you
+must explicitly call `cycle_balance_start_timer`. Timer state and the cached
+balance are in-memory only and do not survive an upgrade. While tracking is
+off, `get_cycle_balance` returns a clear error instead of a stale value.
+
+All endpoints below require **admin role**:
+- `cycle_balance_start_timer`, `cycle_balance_stop_timer` need `AdminUpdate`
+  role (controller or whitelisted via `assignAdminRole`).
+- `get_cycle_balance` needs `AdminQuery` role.
+
+```bash
+# ------------------------------------------------------------------
+# Turn ON cycle-balance tracking (REQUIRED after every install / upgrade).
+# Refreshes the balance once immediately, then re-reads it hourly.
+dfx canister call llama_cpp cycle_balance_start_timer '()'
+# -> (variant { Ok = record { status_code = 200 : nat16 } })
+
+# Read the cached balance (admin query, fast). updated_at_ns is the
+# IC_API::time() at which the snapshot was taken.
+dfx canister call llama_cpp get_cycle_balance '()'
+# -> (variant { Ok = record { cycle_balance = ... : nat; updated_at_ns = ... : nat64 } })
+
+# If tracking is OFF, the query returns a clear error instead of a stale value:
+# -> (variant { Err = variant { Other = "cycle balance tracking is off — an admin must call cycle_balance_start_timer" } })
+
+# Turn OFF cycle-balance tracking
+dfx canister call llama_cpp cycle_balance_stop_timer '()'
+# -> (variant { Ok = record { status_code = 200 : nat16 } })
+```
+
 # Wasm Verification (pre onicai SNS)
 
 > **NOTE:** This workflow was created for the **pre onicai SNS verification

--- a/native/main.cpp
+++ b/native/main.cpp
@@ -5,6 +5,7 @@
 #include "test_admin_rbac.h"
 #include "test_cache_cleanup.h"
 #include "test_canister_functions.h"
+#include "test_cycle_balance.h"
 #include "test_files.h"
 #include "test_qwen2.h"
 #include "test_tiny_stories.h"
@@ -31,6 +32,7 @@ int main() {
   test_admin_rbac(mockIC);
   test_cache_cleanup(mockIC);
   test_canister_functions(mockIC);
+  test_cycle_balance(mockIC);
   test_files(mockIC);
   test_tiny_stories(mockIC);
   test_qwen2(mockIC);

--- a/native/test_cycle_balance.cpp
+++ b/native/test_cycle_balance.cpp
@@ -1,0 +1,173 @@
+// Native tests for the recurring cycle-balance monitor.
+//
+// Strategy:
+//   - Test the refresh worker by direct call to refresh_cycle_balance_body()
+//     so we bypass the candid encode/decode boundary; assertions read the
+//     extern state in cycle_balance.h directly. The MockIC seeds the cycle
+//     balance with MOCKIC_INITIAL_CYCLES_BALANCE (3'000'000'000'000), and
+//     IC_API::time() is pinned via ic0mock_set_time_override so updated_at_ns
+//     is deterministic.
+//   - Test the start/stop endpoints via mockIC.run_test, verifying timer
+//     registry size via IcTimers::instance().size() and the g_*_timer_id.
+//   - Test the "tracking is off" and access-denied responses via
+//     mockIC.run_test; the expected candid hex is the ACTUAL C++ output of
+//     CandidTypeVariant{"Err", CandidTypeVariant{"Other", text}} (the type
+//     table ordering differs from didc's encoding — see CLAUDE.md tip).
+
+#include "test_cycle_balance.h"
+
+#include "../src/cycle_balance.h"
+
+#include "ic0.h"
+#include "ic_api.h"
+#include "ic_timers.h"
+#include "mock_ic.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+namespace {
+
+int expect_eq_u64(const char *label, uint64_t actual, uint64_t expected) {
+  if (actual != expected) {
+    std::cout << "FAIL: " << label << " expected " << expected << ", got "
+              << actual << '\n';
+    return 1;
+  }
+  std::cout << "PASS: " << label << " == " << actual << '\n';
+  return 0;
+}
+
+int expect_true(const char *label, bool cond) {
+  if (!cond) {
+    std::cout << "FAIL: " << label << '\n';
+    return 1;
+  }
+  std::cout << "PASS: " << label << '\n';
+  return 0;
+}
+
+} // namespace
+
+void test_cycle_balance(MockIC &mockIC) {
+  std::string controller_principal{MOCKIC_CONTROLLER};
+  std::string anonymous_principal{"2vxsx-fae"};
+  bool silent_on_trap = true;
+
+  // didc encode '()'
+  const std::string EMPTY_INPUT = "4449444c0000";
+  // ACTUAL C++ output of send_access_denied_api_error (matches
+  // test_cache_cleanup's hardcoded value).
+  const std::string ACCESS_DENIED_API_ERROR =
+      "4449444c026b01b0ad8fcd0c716b01c5fed20100010100000d4163636573732044656e696"
+      "564";
+  // ACTUAL C++ output for the "tracking is off" error. Same nested
+  // Err/Other/text structure as ACCESS_DENIED — only the trailing length byte
+  // (0x4e = 78) and the UTF-8 text bytes differ (note the em-dash e2 80 94).
+  const std::string TRACKING_OFF_ERROR =
+      "4449444c026b01b0ad8fcd0c716b01c5fed20100010100004e6379636c652062616c616e63"
+      "6520747261636b696e67206973206f666620e2809420616e2061646d696e206d7573742063"
+      "616c6c206379636c655f62616c616e63655f73746172745f74696d6572";
+
+  int extra_failures = 0;
+
+  std::cout << "\n========== test_cycle_balance ==========\n";
+
+  IC_API::cancel_all_timers();
+  g_cycle_balance_timer_id = 0;
+
+  // -----------------------------------------------------------------------
+  // Scenario 1: the refresh worker caches the (mock) cycle balance and the
+  // current IC time.
+  // -----------------------------------------------------------------------
+  {
+    ic0mock_set_time_override(123456789);
+    g_cycle_balance = 0;
+    g_cycle_balance_updated_at_ns = 0;
+
+    refresh_cycle_balance_body();
+
+    extra_failures += expect_true(
+        "[refresh] cycle_balance == MOCKIC initial 3'000'000'000'000",
+        g_cycle_balance == static_cast<__uint128_t>(3000000000000ULL));
+    extra_failures += expect_eq_u64("[refresh] updated_at_ns == time override",
+                                    g_cycle_balance_updated_at_ns, 123456789);
+
+    ic0mock_clear_time_override();
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 2: get_cycle_balance returns the clear "tracking is off" error
+  // when the timer is not armed (g_cycle_balance_timer_id == 0).
+  // -----------------------------------------------------------------------
+  IC_API::cancel_all_timers();
+  g_cycle_balance_timer_id = 0;
+  mockIC.run_test("get_cycle_balance (tracking off)", get_cycle_balance,
+                  EMPTY_INPUT, TRACKING_OFF_ERROR, silent_on_trap,
+                  controller_principal);
+
+  // -----------------------------------------------------------------------
+  // Scenario 3: the anonymous principal is denied on every endpoint (auth is
+  // checked before the tracking-off check, so it short-circuits to denied).
+  // -----------------------------------------------------------------------
+  mockIC.run_test("get_cycle_balance (anon denied)", get_cycle_balance,
+                  EMPTY_INPUT, ACCESS_DENIED_API_ERROR, silent_on_trap,
+                  anonymous_principal);
+  mockIC.run_test("cycle_balance_start_timer (anon denied)",
+                  cycle_balance_start_timer, EMPTY_INPUT,
+                  ACCESS_DENIED_API_ERROR, silent_on_trap, anonymous_principal);
+  mockIC.run_test("cycle_balance_stop_timer (anon denied)",
+                  cycle_balance_stop_timer, EMPTY_INPUT,
+                  ACCESS_DENIED_API_ERROR, silent_on_trap, anonymous_principal);
+
+  // -----------------------------------------------------------------------
+  // Scenario 4: start arms the timer (and refreshes once); stop cancels it.
+  // -----------------------------------------------------------------------
+  extra_failures += expect_eq_u64("[start] registry empty pre-start",
+                                  IcTimers::instance().size(), 0);
+
+  mockIC.run_test("cycle_balance_start_timer", cycle_balance_start_timer,
+                  EMPTY_INPUT, "", silent_on_trap, controller_principal);
+
+  extra_failures += expect_eq_u64("[start] registry size == 1 after start",
+                                  IcTimers::instance().size(), 1);
+  extra_failures += expect_true("[start] timer id set after start",
+                                g_cycle_balance_timer_id != 0);
+
+  // Idempotent: second start must not double-register.
+  mockIC.run_test("cycle_balance_start_timer (idempotent)",
+                  cycle_balance_start_timer, EMPTY_INPUT, "", silent_on_trap,
+                  controller_principal);
+  extra_failures += expect_eq_u64("[idempotent] registry still 1",
+                                  IcTimers::instance().size(), 1);
+
+  // With tracking on, the query returns Ok (no trap; value carries a
+  // timestamp so we don't pin the exact output hex here — the smoke test
+  // verifies the Ok content over real Candid).
+  mockIC.run_test("get_cycle_balance (ok path, tracking on)", get_cycle_balance,
+                  EMPTY_INPUT, "", silent_on_trap, controller_principal);
+
+  mockIC.run_test("cycle_balance_stop_timer", cycle_balance_stop_timer,
+                  EMPTY_INPUT, "", silent_on_trap, controller_principal);
+
+  extra_failures += expect_eq_u64("[stop] registry size == 0 after stop",
+                                  IcTimers::instance().size(), 0);
+  extra_failures += expect_true("[stop] timer id reset after stop",
+                                g_cycle_balance_timer_id == 0);
+
+  // Cleanup so leftover timers/state do not affect later tests.
+  IC_API::cancel_all_timers();
+  g_cycle_balance_timer_id = 0;
+
+  std::cout << "test_cycle_balance extra_failures: " << extra_failures
+            << "\n========================================\n\n";
+  if (extra_failures > 0) {
+    // Surface the failure count via mockIC's pass/fail summary by running a
+    // synthetic failing test (extra_failures don't flow through run_test).
+    mockIC.run_test(
+        "test_cycle_balance: extra_failures detected (see PASS/FAIL log above)",
+        get_cycle_balance, EMPTY_INPUT, "DELIBERATE_FAIL_TO_RAISE_ALARM",
+        silent_on_trap, controller_principal);
+  }
+}

--- a/native/test_cycle_balance.h
+++ b/native/test_cycle_balance.h
@@ -1,0 +1,3 @@
+#pragma once
+#include "mock_ic.h"
+void test_cycle_balance(MockIC &mockIC);

--- a/scripts/qa_deploy_and_pytest.py
+++ b/scripts/qa_deploy_and_pytest.py
@@ -37,6 +37,7 @@ def main() -> int:
         test_path_canister = "test/test_canister_functions.py"
         test_path_promptcache = "test/test_promptcache.py"
         test_path_files = "test/test_files.py"
+        test_path_cycle_balance = "test/test_cycle_balance.py"
         for test in tests:
             filename = test["filename"]
             canister_filename = test["canister_filename"]
@@ -46,6 +47,7 @@ def main() -> int:
                 test_path_canister,
                 test_path_promptcache,
                 test_path_files,
+                test_path_cycle_balance,
                 test_path_model,
             ]
 

--- a/src/cycle_balance.cpp
+++ b/src/cycle_balance.cpp
@@ -1,0 +1,125 @@
+// Recurring canister cycle-balance monitor — implementation.
+// See cycle_balance.h for the high-level contract.
+
+#include "cycle_balance.h"
+
+#include "auth.h"
+#include "ic0.h"
+#include "ic_api.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+// --- Config --------------------------------------------------------------
+namespace {
+constexpr uint64_t NS_PER_SEC = 1'000'000'000ULL;
+constexpr uint64_t CYCLE_BALANCE_PERIOD_NS = 3600ULL * NS_PER_SEC; // 1 hour
+} // namespace
+
+// --- File-scope state (extern in cycle_balance.h for native-test access) -
+//
+// In-memory only; wiped on every canister upgrade. `g_cycle_balance` holds
+// the most recent snapshot; `g_cycle_balance_updated_at_ns` is the IC_API
+// time at which it was taken; `g_cycle_balance_timer_id` is the active timer
+// id (0 = not armed, i.e. tracking is off).
+__uint128_t g_cycle_balance = 0;
+uint64_t g_cycle_balance_updated_at_ns = 0;
+uint64_t g_cycle_balance_timer_id = 0;
+
+namespace {
+
+// Re-arm the recurring timer with the hourly period. Caller must have first
+// cancelled any existing timer (id stored in g_cycle_balance_timer_id).
+void arm_cycle_balance_timer_() {
+  g_cycle_balance_timer_id = IC_API::set_timer_recurring(
+      CYCLE_BALANCE_PERIOD_NS, []() { refresh_cycle_balance_body(); });
+}
+
+} // namespace
+
+// --- Worker ---------------------------------------------------------------
+//
+// Reads the live cycle balance via the raw ic0 import — mirrors
+// IC_API::get_canister_self_cycle_balance() — so it can run inside the timer
+// callback without constructing its own IC_API.
+void refresh_cycle_balance_body() {
+  __uint128_t bal;
+  ic0_canister_cycle_balance128(reinterpret_cast<uintptr_t>(&bal));
+  g_cycle_balance = bal;
+  g_cycle_balance_updated_at_ns = IC_API::time();
+}
+
+// --- Endpoints ------------------------------------------------------------
+
+void cycle_balance_start_timer() {
+  IC_API ic_api(CanisterUpdate{std::string(__func__)}, false);
+  if (!has_admin_update_role(ic_api)) {
+    send_access_denied_api_error(ic_api);
+    return;
+  }
+  ic_api.from_wire();
+
+  // Idempotent: cancel any existing armed timer before re-arming.
+  if (g_cycle_balance_timer_id != 0) {
+    IC_API::cancel_timer(g_cycle_balance_timer_id);
+  }
+  // Refresh once immediately so the cached value is meaningful before the
+  // first hourly tick (set_timer_recurring first fires one period later).
+  refresh_cycle_balance_body();
+  arm_cycle_balance_timer_();
+
+  std::string msg = "cycle balance tracking armed; period_seconds=" +
+                    std::to_string(CYCLE_BALANCE_PERIOD_NS / NS_PER_SEC);
+  std::cout << "llama_cpp: " << std::string(__func__) << " - " << msg
+            << std::endl;
+
+  CandidTypeRecord status_code_record;
+  status_code_record.append("status_code", CandidTypeNat16{200});
+  ic_api.to_wire(CandidTypeVariant{"Ok", status_code_record});
+}
+
+void cycle_balance_stop_timer() {
+  IC_API ic_api(CanisterUpdate{std::string(__func__)}, false);
+  if (!has_admin_update_role(ic_api)) {
+    send_access_denied_api_error(ic_api);
+    return;
+  }
+  ic_api.from_wire();
+
+  if (g_cycle_balance_timer_id != 0) {
+    IC_API::cancel_timer(g_cycle_balance_timer_id);
+    g_cycle_balance_timer_id = 0;
+    std::cout << "llama_cpp: " << std::string(__func__)
+              << " - cycle balance tracking stopped" << std::endl;
+  }
+
+  CandidTypeRecord status_code_record;
+  status_code_record.append("status_code", CandidTypeNat16{200});
+  ic_api.to_wire(CandidTypeVariant{"Ok", status_code_record});
+}
+
+void get_cycle_balance() {
+  IC_API ic_api(CanisterQuery{std::string(__func__)}, false);
+  if (!has_admin_query_role(ic_api)) {
+    send_access_denied_api_error(ic_api);
+    return;
+  }
+  ic_api.from_wire();
+
+  // If the timer is not armed, the cached value is stale/zero — return a
+  // clear error instead of a misleading number.
+  if (g_cycle_balance_timer_id == 0) {
+    ic_api.to_wire(CandidTypeVariant{
+        "Err",
+        CandidTypeVariant{
+            "Other", CandidTypeText{"cycle balance tracking is off — an admin "
+                                    "must call cycle_balance_start_timer"}}});
+    return;
+  }
+
+  CandidTypeRecord r;
+  r.append("cycle_balance", CandidTypeNat{g_cycle_balance});
+  r.append("updated_at_ns", CandidTypeNat64{g_cycle_balance_updated_at_ns});
+  ic_api.to_wire(CandidTypeVariant{"Ok", CandidTypeRecord{r}});
+}

--- a/src/cycle_balance.h
+++ b/src/cycle_balance.h
@@ -1,0 +1,45 @@
+// Recurring canister cycle-balance monitor.
+//
+// Refreshes a cached snapshot of the canister's cycle balance on a recurring
+// schedule (hourly) using the IC's `canister_cycle_balance128` system call.
+// Admins read the cached value cheaply via the `get_cycle_balance` query.
+//
+// Lifecycle is operator-driven: the timer is NOT auto-armed in
+// canister_init / canister_post_upgrade. The deploy/upgrade workflow must
+// explicitly call `cycle_balance_start_timer` after the canister is
+// reachable. Timer state and the cached balance are in-memory only and do
+// not survive an upgrade. While the timer is not armed, `get_cycle_balance`
+// returns a clear "tracking is off" error rather than a stale value.
+#pragma once
+
+#include "wasm_symbol.h"
+
+#include <cstdint>
+
+// --- Endpoints ------------------------------------------------------------
+// Update endpoints — RBAC: has_admin_update_role required.
+void cycle_balance_start_timer()
+    WASM_SYMBOL_EXPORTED("canister_update cycle_balance_start_timer");
+void cycle_balance_stop_timer()
+    WASM_SYMBOL_EXPORTED("canister_update cycle_balance_stop_timer");
+
+// Query endpoint — RBAC: has_admin_query_role required.
+void get_cycle_balance()
+    WASM_SYMBOL_EXPORTED("canister_query get_cycle_balance");
+
+// --- Internal helper ------------------------------------------------------
+// Reads the live cycle balance via the raw ic0 import and caches it. Safe to
+// call from any context: an entry-point handler that already has its own
+// IC_API on the stack, OR the timer callback (which runs inside
+// canister_global_timer's CanisterGlobalTimer IC_API frame). This function
+// does NOT construct an IC_API instance.
+void refresh_cycle_balance_body();
+
+// --- Test introspection (extern for native tests) ------------------------
+// These are file-scope globals in cycle_balance.cpp; they are exposed via
+// extern declarations here exclusively so native tests in
+// native/test_cycle_balance.cpp can read them directly without going through
+// Candid. Production code MUST NOT mutate them.
+extern __uint128_t g_cycle_balance;
+extern uint64_t g_cycle_balance_updated_at_ns;
+extern uint64_t g_cycle_balance_timer_id;

--- a/src/llama_cpp.did
+++ b/src/llama_cpp.did
@@ -290,6 +290,17 @@ type CacheCleanupConfigRecord = record {
 };
 
 // -----------------------------------------------------
+// Recurring cycle-balance monitor
+type CycleBalanceRecord = record {
+  cycle_balance : nat;       // cached canister cycle balance (128-bit)
+  updated_at_ns : nat64      // IC_API::time() when the snapshot was taken
+};
+type CycleBalanceRecordResult = variant {
+  Err : ApiError;            // includes "tracking is off" when timer not armed
+  Ok : CycleBalanceRecord
+};
+
+// -----------------------------------------------------
 // The endpoint services of our canister
 service : {
   // canister
@@ -331,6 +342,11 @@ service : {
   cache_cleanup_now : () -> (CacheCleanupStatsResult);
   get_cache_cleanup_stats : () -> (CacheCleanupStatsResult) query;
   set_cache_cleanup_config : (CacheCleanupConfigInput) -> (CacheCleanupConfigResult);
+
+  // Recurring cycle-balance monitor (admin-only)
+  cycle_balance_start_timer : () -> (StatusCodeRecordResult);
+  cycle_balance_stop_timer : () -> (StatusCodeRecordResult);
+  get_cycle_balance : () -> (CycleBalanceRecordResult) query;
 
   // Logging endpoints
   remove_log_file : (InputRecord) -> (OutputRecordResult);

--- a/test/test_cycle_balance.py
+++ b/test/test_cycle_balance.py
@@ -1,0 +1,126 @@
+"""Test the recurring cycle-balance monitor.
+
+First deploy the canister:
+$ icpp build-wasm
+$ dfx deploy --network local
+
+Then run the tests:
+$ pytest -vv --network local test/test_cycle_balance.py
+
+Lifecycle is operator-driven (like the prompt-cache cleanup timer): the timer
+is not auto-armed, so right after a clean deploy `get_cycle_balance` returns a
+clear "tracking is off" error. Starting the timer refreshes the cached balance
+once immediately, so the Ok value is non-zero without waiting an hour.
+"""
+
+# pylint: disable=missing-function-docstring, unused-import, line-too-long
+
+import re
+from pathlib import Path
+from typing import Dict
+
+from icpp.smoketest import call_canister_api
+
+DFX_JSON_PATH = Path(__file__).parent / "../dfx.json"
+CANISTER_NAME = "llama_cpp"
+
+TRACKING_OFF_MESSAGE = (
+    "cycle balance tracking is off — an admin must call cycle_balance_start_timer"
+)
+
+
+# ---------- helpers ---------------------------------------------------------
+
+
+def _call(method: str, argument: str, network: str) -> str:
+    return call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method=method,
+        canister_argument=argument,
+        network=network,
+    )
+
+
+def _start(network: str) -> str:
+    return _call("cycle_balance_start_timer", "()", network)
+
+
+def _stop(network: str) -> str:
+    return _call("cycle_balance_stop_timer", "()", network)
+
+
+def _extract_nat(response: str, name: str, candid_type: str) -> int:
+    """Pull a `<name> = <int> : <candid_type>` field out of a candid response."""
+    match = re.search(rf"{name}\s*=\s*([0-9_]+)\s*:\s*{candid_type}", response)
+    if not match:
+        raise AssertionError(f"field {name!r} not found in response: {response}")
+    return int(match.group(1).replace("_", ""))
+
+
+# ---------- access-denied test ---------------------------------------------
+
+
+def test__cycle_balance_endpoints_require_auth(
+    identity_anonymous: Dict[str, str], network: str
+) -> None:
+    """All three endpoints (including the query) reject anonymous callers."""
+    assert identity_anonymous["principal"] == "2vxsx-fae"
+
+    expected = '(variant { Err = variant { Other = "Access Denied" } })'
+
+    for method, arg in [
+        ("cycle_balance_start_timer", "()"),
+        ("cycle_balance_stop_timer", "()"),
+        ("get_cycle_balance", "()"),
+    ]:
+        response = _call(method, arg, network)
+        assert response == expected, f"{method}: got {response!r}"
+
+
+# ---------- tracking-off error (timer not armed) ---------------------------
+
+
+def test__get_cycle_balance_off_returns_clear_error(network: str) -> None:
+    # Guarantee the timer is off regardless of prior tests in this session.
+    _stop(network)
+
+    response = _call("get_cycle_balance", "()", network)
+    assert "Err" in response, response
+    assert TRACKING_OFF_MESSAGE in response, response
+
+
+# ---------- start arms the timer -------------------------------------------
+
+
+def test__cycle_balance_start_timer(network: str) -> None:
+    response = _start(network)
+    assert response == "(variant { Ok = record { status_code = 200 : nat16;} })", response
+
+
+# ---------- get returns a fresh, non-zero balance --------------------------
+
+
+def test__get_cycle_balance_ok_after_start(network: str) -> None:
+    # start refreshes the cached balance once immediately.
+    _start(network)
+
+    response = _call("get_cycle_balance", "()", network)
+    assert "Ok" in response, response
+
+    cycle_balance = _extract_nat(response, "cycle_balance", "nat")
+    updated_at_ns = _extract_nat(response, "updated_at_ns", "nat64")
+    assert cycle_balance > 0, f"expected non-zero cycle_balance, got {cycle_balance}"
+    assert updated_at_ns > 0, f"expected non-zero updated_at_ns, got {updated_at_ns}"
+
+
+# ---------- stop turns tracking back off -----------------------------------
+
+
+def test__cycle_balance_stop_timer(network: str) -> None:
+    response = _stop(network)
+    assert response == "(variant { Ok = record { status_code = 200 : nat16;} })", response
+
+    # After stop, the query again reports tracking is off.
+    off = _call("get_cycle_balance", "()", network)
+    assert TRACKING_OFF_MESSAGE in off, off


### PR DESCRIPTION
## Context

Operators need visibility into the canister's cycle balance to avoid it being frozen/deleted when cycles run low. This adds a cheap, admin-readable snapshot of the cycle balance that is refreshed on an hourly schedule, rather than requiring a live system call on every check.

## What this adds

- **`cycle_balance` state** refreshed by an **hourly recurring timer**, plus a freshness timestamp (`updated_at_ns`).
- **`get_cycle_balance`** — an **AdminQuery-gated** query returning `record { cycle_balance : nat; updated_at_ns : nat64 }`. When the timer is not armed it returns a clear error instead of a stale value: `Err = variant { Other = "cycle balance tracking is off — an admin must call cycle_balance_start_timer" }`.
- **`cycle_balance_start_timer` / `cycle_balance_stop_timer`** — **AdminUpdate-gated** operator endpoints. `start` refreshes the balance once immediately (so it is non-zero before the first hourly tick), then arms the recurring timer; it is idempotent.

The design mirrors the existing `cache_cleanup` recurring-timer feature for consistency. Lifecycle is operator-driven (the repo has no `canister_post_upgrade` hook; timer state is in-memory and wiped on upgrade).

## Implementation notes

- The timer worker reads the balance via the raw `ic0_canister_cycle_balance128` import (mirroring `IC_API::get_canister_self_cycle_balance()`), so it does **not** construct its own `IC_API` — required because the callback runs inside the `canister_global_timer` `IC_API` frame.
- The 128-bit balance marshals to Candid `nat` via `CandidTypeNat{__uint128_t}`.

## Files

- `src/cycle_balance.{h,cpp}` — feature implementation
- `src/llama_cpp.did` (+ regenerated declarations) — types and service methods
- `native/test_cycle_balance.{cpp,h}` + `native/main.cpp` — native MockIC tests
- `test/test_cycle_balance.py` + `scripts/qa_deploy_and_pytest.py` — pytest smoke tests, wired into the QA scenario
- `README.md` — "Cycle Balance Monitoring" section
- `.claude/skills/new-feature-development/SKILL.md` — reusable feature-development lifecycle skill

## Verification

- Native MockIC: **111/111 pass** (incl. new `test_cycle_balance` suite)
- `make all-static`: clang-format clean, pylint **10.00/10**, mypy clean
- Local deploy — endpoint behaviors confirmed:
  - before arming → tracking-off error
  - `cycle_balance_start_timer` → `Ok { status_code = 200 }`
  - after arming → `Ok { cycle_balance = … : nat; updated_at_ns = … : nat64 }`
  - after `stop` → tracking-off error again
- Smoke suites vs live canister (`canister_functions` + `files` + `cycle_balance`): **49/49 pass** (incl. 5 new tests)

**Not run in this environment:** the model-dependent part of `make test-llm-wasm` and the qwen2 README walkthrough. Both require `python -m scripts.upload`, which fails with `404 .../api/v3/.../query` — an `icp_core` agent vs dfx 0.29.2 replica mismatch, before any feature code runs. This is a pre-existing tooling issue affecting the whole project's model workflow, not this change.