### PR TITLE
Upgrade to icpp-pro 6.0.0: named test identity, re-enable 4 non-controller tests

### DIFF
--- a/.claude/skills/llama_cpp_canister-release-test/SKILL.md
+++ b/.claude/skills/llama_cpp_canister-release-test/SKILL.md
@@ -69,11 +69,18 @@ pip install -r requirements.txt
 `icp.yaml` defines two canisters — deploy **`llama_cpp`** (the Qwen3 default), not both.
 `icp network start -d` picks a random ephemeral port; never hardcode `localhost:8000`.
 
+Deploy as `llama-cpp-testing`: since icpp-pro 6.0.0 pytest is told which identity to
+run as, and a canister's controller is whoever deployed it, so the two must agree.
+Create it once with `icp identity new llama-cpp-testing --storage plaintext`.
+Exporting `ICPP_PRO_TEST_IDENTITY` makes `python -m scripts.upload` (step 7) sign as
+that identity too, which it must — only a controller may upload.
+
 ```bash
 cd /tmp/llama_cpp_release_test/<TAG>
+export ICPP_PRO_TEST_IDENTITY=llama-cpp-testing
 icp network start -d
-icp deploy llama_cpp -e local -y
-icp canister settings update llama_cpp --wasm-memory-limit 4026531840 -e local   # 3.75 GiB — REQUIRED for Qwen3
+icp deploy llama_cpp -e local -y --identity "$ICPP_PRO_TEST_IDENTITY"
+icp canister settings update llama_cpp --wasm-memory-limit 4026531840 -e local --identity "$ICPP_PRO_TEST_IDENTITY"   # 3.75 GiB — REQUIRED for Qwen3
 icp canister top-up llama_cpp --amount 20000000000000 -e local                   # ~20T cycles
 icp canister call llama_cpp health '()' -e local --query                         # -> Ok 200
 icp canister status llama_cpp -e local | grep "Wasm memory limit"                # -> 4_026_531_840
@@ -82,8 +89,8 @@ icp canister status llama_cpp -e local | grep "Wasm memory limit"               
 ## 5. Check the get_memory_status endpoint (new in v0.13.0)
 
 ```bash
-icp canister call llama_cpp get_memory_status '()' -e local --query                      # -> Ok { wasm_heap_bytes; stable_bytes }
-icp canister call llama_cpp get_memory_status '()' -e local --query --identity anonymous  # -> Err "Access Denied"
+icp canister call llama_cpp get_memory_status '()' -e local --query --identity "$ICPP_PRO_TEST_IDENTITY"  # -> Ok { wasm_heap_bytes; stable_bytes }
+icp canister call llama_cpp get_memory_status '()' -e local --query --identity anonymous                  # -> Err "Access Denied"
 ```
 
 ## 6. Get the Qwen3 model
@@ -121,7 +128,7 @@ Optionally confirm on-chain: `icp canister call llama_cpp -e local uploaded_file
 
 ```bash
 cd /tmp/llama_cpp_release_test/<TAG>
-pytest -vv --network local test/test_qwen3.py
+pytest -vv --network local --identity "$ICPP_PRO_TEST_IDENTITY" test/test_qwen3.py
 ```
 
 The suite loads Qwen3 at `--ctx-size 16384 --batch-size 64 --ubatch-size 64` (dual q8_0)
@@ -139,9 +146,9 @@ deterministic failure of the other tests is a real problem.
 ## 9. (Optional) Qwen2.5 regression
 
 The release also serves the previous default, Qwen2.5-0.5B, via the `llama_cpp_qwen25`
-canister and `test/test_qwen2.py`. To exercise it: `icp deploy llama_cpp_qwen25 -e local -y`, download
+canister and `test/test_qwen2.py`. To exercise it: `icp deploy llama_cpp_qwen25 -e local -y --identity "$ICPP_PRO_TEST_IDENTITY"`, download
 the Qwen2.5 gguf (sha256 `ca59ca7f13d0e15a8cfa77bd17e65d24f6844b554a7b6c12e07a5f89ff76844e`),
-upload it to `llama_cpp_qwen25`, then `pytest -vv --network local test/test_qwen2.py`.
+upload it to `llama_cpp_qwen25`, then `pytest -vv --network local --identity "$ICPP_PRO_TEST_IDENTITY" test/test_qwen2.py`.
 
 ## 10. Cleanup
 

--- a/.claude/skills/new-feature-development/SKILL.md
+++ b/.claude/skills/new-feature-development/SKILL.md
@@ -100,15 +100,20 @@ source /opt/miniconda3/etc/profile.d/conda.sh && conda activate llama_cpp_canist
 icpp build-native && ./build-native/mockic.exe
 
 # WASM build + local deploy (regenerates declarations):
+# Deploy as the identity the tests call as: since icpp-pro 6.0.0 pytest is told
+# which identity to run as, and a canister's controller is whoever deployed it.
+# `make test-llm-wasm` creates it; otherwise:
+#   icp identity new llama-cpp-testing --storage plaintext
+export ICPP_PRO_TEST_IDENTITY=llama-cpp-testing
 icpp build-wasm
 icp network start -d
-icp deploy -e local -y
+icp deploy -e local -y --identity "$ICPP_PRO_TEST_IDENTITY"
 
 # Exercise the new endpoints:
-icp canister call llama_cpp <new_endpoint> '()' -e local
+icp canister call llama_cpp <new_endpoint> '()' -e local --identity "$ICPP_PRO_TEST_IDENTITY"
 
 # New smoke tests:
-pytest -vv --network local test/test_<feature>.py
+pytest -vv --network local --identity "$ICPP_PRO_TEST_IDENTITY" test/test_<feature>.py
 ```
 
 ## 8. Verify — full regression
@@ -137,8 +142,8 @@ set_max_tokens → new_chat → run_update until `generated_eog = true`), then
 exercise the new feature on the live, model-loaded canister. Confirms no
 regression in the inference path. Also run:
 ```bash
-pytest -vv --network local test/test_canister_functions.py
-pytest -vv --network local test/test_qwen2.py
+pytest -vv --network local --identity "$ICPP_PRO_TEST_IDENTITY" test/test_canister_functions.py
+pytest -vv --network local --identity "$ICPP_PRO_TEST_IDENTITY" test/test_qwen2.py
 ```
 
 ## 10. Commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,22 +113,38 @@ def test__your_test_name(network: str, principal: str) -> None:
 ```
 
 **Running smoke tests:**
+
+Since icpp-pro 6.0.0, pytest must be told which icp identity to run as — it
+never reads or writes the machine-wide active identity (`icp identity default`).
+Most endpoints are controller-only, so it must be the identity that deployed the
+canister.
+
 ```bash
-# Deploy first
+# Once: create the two test identities (plaintext, so icpp-pro can export the
+# key and sign locally). `make test-llm-wasm` does this for you.
+icp identity new llama-cpp-testing --storage plaintext
+icp identity new llama-cpp-other-user --storage plaintext   # never a controller
+
+# Deploy first, as the identity the tests will call as
 icp network start -d
-icp deploy -e local -y
+icp deploy -e local -y --identity llama-cpp-testing
 
 # Run specific test
-pytest -vv --network local test/test_files.py::test__your_test_name
+pytest -vv --network local --identity llama-cpp-testing test/test_files.py::test__your_test_name
 
 # Run all tests in a file
-pytest -vv --network local test/test_files.py
+pytest -vv --network local --identity llama-cpp-testing test/test_files.py
 ```
+
+`--identity` can be replaced by exporting `ICPP_PRO_TEST_IDENTITY`.
 
 **Available fixtures (from conftest.py):**
 - `network` - "local" or "production"
-- `principal` - Current identity's principal
-- `identity_anonymous` - Dict with anonymous identity info
+- `identity` - Name of the identity the tests run as
+- `principal` - That identity's principal
+- `identity_default` - Dict with the session identity's info (name kept for backwards compat; it is NOT an identity called `default`)
+- `identity_anonymous` - Dict with anonymous identity info; makes a test's calls run as anonymous
+- `identity_non_controller` - Dict with a second, non-controller identity's info (project fixture, see `test/conftest.py`). Pass its `identity` to `call_canister_api(..., identity=...)` to call as an authenticated but unauthorized caller
 
 ## Code Patterns
 
@@ -202,7 +218,7 @@ llama_cpp_canister/
 3. **Add unit test** to appropriate `native/test_*.cpp`
 4. **Build and run unit tests**: `icpp build-native && ./build-native/mockic.exe`
 5. **Add smoke test** to appropriate `test/test_*.py`
-6. **Deploy and run smoke tests**: `icp deploy -e local -y && pytest -vv --network local test/test_*.py`
+6. **Deploy and run smoke tests**: `icp deploy -e local -y --identity llama-cpp-testing && pytest -vv --network local --identity llama-cpp-testing test/test_*.py`
 
 ## Tips
 

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,23 @@ CLANG_TIDY = $(ICPP_COMPILER_ROOT)/bin/clang-tidy
 
 
 ###########################################################################
+# The icp identities used by the wasm QA (deploy + pytest).
+#
+# icpp-pro >= 6.0.0 never reads or writes the machine-wide active identity
+# (`icp identity default`): pytest is told which identity to run as, via
+# ${ICPP_PRO_TEST_IDENTITY}. A canister's controller is whoever deployed it, so
+# scripts/qa_deploy_and_pytest.py deploys as that same identity.
+#
+# ICPP_PRO_TEST_IDENTITY_NON_CONTROLLER is a second identity that is never a
+# controller. It is what the `*_non_controller` tests in test/test_files.py call
+# as, to prove the endpoints deny a caller who is neither a controller nor an
+# admin.
+ICPP_PRO_TEST_IDENTITY ?= llama-cpp-testing
+ICPP_PRO_TEST_IDENTITY_NON_CONTROLLER ?= llama-cpp-other-user
+export ICPP_PRO_TEST_IDENTITY
+export ICPP_PRO_TEST_IDENTITY_NON_CONTROLLER
+
+###########################################################################
 # CI/CD - Phony Makefile targets
 #
 .PHONY: all-tests
@@ -86,14 +103,24 @@ test-llm-native:
 	./build-native/mockic.exe
 
 .PHONY: test-llm-wasm
-test-llm-wasm:
-	# icp does not auto-create a `default` identity (dfx did). Create a keyed,
-	# plaintext-stored one so the uploader can export its key non-interactively;
-	# tolerate "already exists" on machines that have it.
-	icp identity new default --storage plaintext 2>/dev/null || true
-	icp identity default default
+test-llm-wasm: icp-test-identities
 	python -m scripts.qa_deploy_and_pytest
-	
+
+# Creates the two QA identities if they do not exist yet, without ever touching
+# the machine-wide active identity.
+#
+# The existence check is `icp identity principal --identity <name>`, not
+# `icp identity list | grep -w <name>`: grep treats `-` as a word boundary, so
+# `<name>-old` would match `<name>` and the identity would silently not be
+# created. They are stored in plaintext because icpp-pro exports the key to sign
+# locally, which a password-protected identity cannot do non-interactively.
+.PHONY: icp-test-identities
+icp-test-identities:
+	@icp identity principal --identity "$(ICPP_PRO_TEST_IDENTITY)" >/dev/null 2>&1 || \
+	  icp identity new "$(ICPP_PRO_TEST_IDENTITY)" --storage plaintext
+	@icp identity principal --identity "$(ICPP_PRO_TEST_IDENTITY_NON_CONTROLLER)" >/dev/null 2>&1 || \
+	  icp identity new "$(ICPP_PRO_TEST_IDENTITY_NON_CONTROLLER)" --storage plaintext
+
 .PHONY: all-static
 all-static: \
 	cpp-format cpp-lint \

--- a/README-Release-Guide.md
+++ b/README-Release-Guide.md
@@ -41,9 +41,15 @@ After the workflow completes:
    - `scripts/` with upload/download tooling
    - `test/` with smoke tests
    - `icp.yaml`, `version.txt`, `requirements.txt`
-3. Optionally deploy and run smoke tests:
+3. Optionally deploy and run smoke tests. Since icpp-pro 6.0.0 pytest must be
+   told which icp identity to run as, and it has to be the identity that
+   deployed the canister (most endpoints are controller-only):
    ```bash
+   # once, if you do not have them yet
+   icp identity new llama-cpp-testing --storage plaintext
+   icp identity new llama-cpp-other-user --storage plaintext  # non-controller, for test_files.py
+
    icp network start -d
-   icp deploy -e local -y
-   pytest -vv --network local test/
+   icp deploy -e local -y --identity llama-cpp-testing
+   pytest -vv --network local --identity llama-cpp-testing test/
    ```

--- a/README-qwen2.5.md
+++ b/README-qwen2.5.md
@@ -58,7 +58,9 @@ icp canister call llama_cpp_qwen25 -e local uploaded_file_details '(record { fil
 )
 ```
 
-Optional pytest QA: `pytest -vv --network local test/test_qwen2.py`
+Optional pytest QA: `pytest -vv --network local --identity "$(icp identity default)" test/test_qwen2.py`
+(since icpp-pro 6.0.0 pytest must be told which identity to run as — it has to be
+the one that deployed the canister; see the main README's smoke-testing section)
 
 ## Load the model
 

--- a/README.md
+++ b/README.md
@@ -238,8 +238,11 @@ You can just grab the latest [release](https://github.com/onicai/llama_cpp_canis
 - Optional: You can now run a pytest based QA, using the icpp-pro smoketesting framework:
 
   ```bash
-  pytest -vv --network local test/test_qwen3.py
+  pytest -vv --network local --identity "$(icp identity default)" test/test_qwen3.py
   ```
+
+  See [Smoke testing the deployed LLM](#smoke-testing-the-deployed-llm) for what
+  `--identity` is and why it is required.
 
 - Load the gguf file into Orthogonal Persisted (OP) working memory
 
@@ -531,17 +534,50 @@ You can run a smoketest on the deployed LLM:
 
 - Deploy the Qwen3-0.6B model as described above
 
+- Tell pytest which icp identity to run as. Since icpp-pro 6.0.0 this is
+  required: the tests never pick up the machine-wide active identity by
+  themselves, because any other process can change it mid-run. Most endpoints
+  are controller-only, so it must be **the identity you deployed the canister
+  with** — if you followed the steps above, that is your active identity:
+
+  ```bash
+  icp identity default    # prints the name to pass as --identity
+  ```
+
+  It must not be password protected: icpp-pro exports the key to sign the calls
+  locally, which a password-protected identity cannot do non-interactively.
+
+  Pass the name as `--identity <name>` (as below), or export
+  `ICPP_PRO_TEST_IDENTITY=<name>` once per shell.
+
 - Run the smoketests for the Qwen3-0.6B LLM deployed to your local IC network:
 
   ```
   # First test the canister functions, like 'health'
-  pytest -vv --network local test/test_canister_functions.py
+  pytest -vv --network local --identity "$(icp identity default)" test/test_canister_functions.py
 
   # Then run the inference tests (multi-turn, non-thinking)
-  pytest -vv --network local test/test_qwen3.py
+  pytest -vv --network local --identity "$(icp identity default)" test/test_qwen3.py
   ```
 
   _(The previous default, Qwen2.5-0.5B, is still covered by `test/test_qwen2.py`.)_
+
+  `test/test_files.py` additionally needs a SECOND identity that is *not* a
+  controller, to verify that the filesystem endpoints deny an authenticated but
+  unauthorized caller. It defaults to `llama-cpp-other-user` and is overridden
+  with `$ICPP_PRO_TEST_IDENTITY_NON_CONTROLLER`:
+
+  ```bash
+  icp identity new llama-cpp-other-user --storage plaintext
+  ```
+
+- Or let the full QA do all of it for you — it creates the two identities
+  (`llama-cpp-testing` and `llama-cpp-other-user`), deploys as the first, and
+  runs every suite, without ever changing your active identity:
+
+  ```bash
+  make test-llm-wasm
+  ```
 
 # Prompt Caching
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,10 @@
 # file separately.
 
 -r scripts/requirements.txt
-icpp-pro>=5.6.0
+# 6.0.0 is a breaking change: pytest is told which icp identity to run as, with
+# `pytest --identity <name>` or ${ICPP_PRO_TEST_IDENTITY}. It never reads or
+# writes the machine-wide active identity. See the Makefile's test-llm-wasm.
+icpp-pro>=6.0.0
 icp-py-core==2.3.1
 # cbor2 is intentionally unpinned: icp-py-core 2.3.1 adds cbor2 6.x compatibility,
 # resolving the frozendict/isinstance(response, dict) breakage that previously

--- a/scripts/2-deploy.sh
+++ b/scripts/2-deploy.sh
@@ -48,18 +48,28 @@ done
 
 echo "Using network type: $NETWORK_TYPE"
 
+# A canister's controller is whoever deployed it, and icpp-pro >= 6.0.0 runs the
+# tests as ${ICPP_PRO_TEST_IDENTITY} instead of the machine-wide active identity.
+# So deploy as that identity whenever it is set, and leave the deploy on the
+# active identity (the normal interactive case) when it is not.
+IDENTITY_ARGS=()
+if [ -n "${ICPP_PRO_TEST_IDENTITY:-}" ]; then
+    IDENTITY_ARGS=(--identity "$ICPP_PRO_TEST_IDENTITY")
+    echo "Using identity: $ICPP_PRO_TEST_IDENTITY"
+fi
+
 #######################################################################
 echo "--------------------------------------------------"
 echo "Deploying the wasm to llama_cpp"
 if [ "$NETWORK_TYPE" = "production" ]; then
     if [ "$SUBNET" = "none" ]; then
-        icp deploy llama_cpp -m $DEPLOY_MODE -y -e $NETWORK_TYPE
+        icp deploy llama_cpp -m $DEPLOY_MODE -y -e $NETWORK_TYPE "${IDENTITY_ARGS[@]}"
     else
-        icp deploy llama_cpp -m $DEPLOY_MODE -y -e $NETWORK_TYPE --subnet $SUBNET
+        icp deploy llama_cpp -m $DEPLOY_MODE -y -e $NETWORK_TYPE --subnet $SUBNET "${IDENTITY_ARGS[@]}"
     fi
 else
-    icp deploy llama_cpp -m $DEPLOY_MODE -y -e $NETWORK_TYPE
-fi 
+    icp deploy llama_cpp -m $DEPLOY_MODE -y -e $NETWORK_TYPE "${IDENTITY_ARGS[@]}"
+fi
 
 echo " "
 echo "--------------------------------------------------"

--- a/scripts/ic_py_canister.py
+++ b/scripts/ic_py_canister.py
@@ -1,6 +1,7 @@
 """Returns the icp-py-core Canister instance, for calling the endpoints."""
 
 import json
+import os
 import sys
 import subprocess
 from pathlib import Path
@@ -10,10 +11,16 @@ from icpp.run_shell_cmd import run_shell_cmd
 
 ROOT_PATH = Path(__file__).parent.parent
 
-# We use the `icp` CLI to look up the network URL, the active identity's private
-# key, and canister ids. (This project migrated from dfx to icp-cli. Unlike dfx,
-# icp emits no deprecation banner on stdout, so no output-scrubbing is needed.)
+# We use the `icp` CLI to look up the network URL, the identity's private key,
+# and canister ids. (This project migrated from dfx to icp-cli. Unlike dfx, icp
+# emits no deprecation banner on stdout, so no output-scrubbing is needed.)
 ICP = "icp"
+
+# The wasm QA deploys as ${ICPP_PRO_TEST_IDENTITY} (see the Makefile), and only
+# a controller may upload. So when that variable is set, sign as that identity
+# rather than as the machine-wide active one - otherwise the upload would be
+# rejected by a canister this process just deployed under a different identity.
+IDENTITY_ENV_VAR = "ICPP_PRO_TEST_IDENTITY"
 
 
 def run_icp_command(cmd: str, quiet: bool = False) -> Optional[str]:
@@ -62,11 +69,14 @@ def get_agent(network: str = "local") -> Agent:
     network_url = json.loads(status_json)["api_url"].rstrip("/")
     print(f"Network URL        = {network_url}")
 
-    # Get the name of the active identity (equivalent of `dfx identity whoami`).
-    identity_whoami = run_icp_command(f"{ICP} identity default")
+    # Get the name of the identity to sign as: ${ICPP_PRO_TEST_IDENTITY} when
+    # set, else the machine-wide active one (`dfx identity whoami`'s successor).
+    identity_whoami = os.environ.get(IDENTITY_ENV_VAR, "").strip() or run_icp_command(
+        f"{ICP} identity default"
+    )
     print(f"Using identity = {identity_whoami}")
 
-    # Get the private key (PEM) of the active identity.
+    # Get the private key (PEM) of that identity.
     private_key = run_icp_command(f"{ICP} identity export {identity_whoami}")
 
     # Create an Identity instance using the private key

--- a/scripts/qa_deploy_and_pytest.py
+++ b/scripts/qa_deploy_and_pytest.py
@@ -1,5 +1,6 @@
 """Deploys & runs pytest in a freshly started local network for some LLMs"""
 
+import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, List
@@ -9,6 +10,31 @@ from icpp.run_shell_cmd import run_shell_cmd
 
 # SCRIPTS_PATH = Path(__file__).parent
 ROOT_PATH = Path(__file__).parent.parent
+
+# The identity to deploy & test as. icpp-pro >= 6.0.0 never uses the
+# machine-wide active identity (`icp identity default`), because any other
+# process can change it mid-run. The `test-llm-wasm` Makefile target creates the
+# identity and exports it; pytest inherits it through the environment, and every
+# icp command below passes it explicitly.
+IDENTITY_ENV_VAR = "ICPP_PRO_TEST_IDENTITY"
+
+
+def get_identity() -> str:
+    """Returns the identity to deploy & test as, or exits with instructions."""
+    identity = os.environ.get(IDENTITY_ENV_VAR, "").strip()
+    if not identity:
+        typer.echo(
+            f"\nERROR: ${IDENTITY_ENV_VAR} is not set.\n\n"
+            "The canister must be deployed by the same identity the tests call\n"
+            "as, because a canister's controller is whoever deployed it.\n\n"
+            "Run this via the Makefile, which creates & exports it:\n\n"
+            "    make test-llm-wasm\n\n"
+            "or set it yourself:\n\n"
+            "    icp identity new <name> --storage plaintext\n"
+            f"    export {IDENTITY_ENV_VAR}=<name>\n"
+        )
+        sys.exit(1)
+    return identity
 
 
 def icp_network_stop() -> None:
@@ -22,7 +48,11 @@ def icp_network_stop() -> None:
 
 def main() -> int:
     """Start local network; Deploy canister; Upload LLM model; Pytest"""
+    identity = get_identity()
+    identity_arg = f" --identity {identity} "
     try:
+        typer.echo(f"--\nDeploying & testing as identity: {identity}")
+
         typer.echo("--\nBuild the wasm")
         run_shell_cmd(
             "icpp build-wasm --to-compile all",
@@ -105,13 +135,14 @@ def main() -> int:
             run_shell_cmd("icp network start -d", cwd=ROOT_PATH)
 
             typer.echo(f"--\nDeploy {ROOT_PATH.name}")
-            run_shell_cmd("icp deploy -e local -y", cwd=ROOT_PATH)
+            run_shell_cmd(f"icp deploy -e local -y{identity_arg}", cwd=ROOT_PATH)
 
             # Top up cycles so loading a larger model can grow wasm memory
             # (otherwise load_model traps with IC0532 insufficient-cycles).
             typer.echo("--\nTop up cycles")
             run_shell_cmd(
-                "icp canister top-up llama_cpp --amount 20000000000000 -e local",
+                "icp canister top-up llama_cpp --amount 20000000000000 -e local"
+                f"{identity_arg}",
                 cwd=ROOT_PATH,
             )
 
@@ -121,7 +152,8 @@ def main() -> int:
                 )
                 run_shell_cmd(
                     "icp canister settings update llama_cpp "
-                    f"--wasm-memory-limit {test['wasm_memory_limit']} -e local",
+                    f"--wasm-memory-limit {test['wasm_memory_limit']} -e local"
+                    f"{identity_arg}",
                     cwd=ROOT_PATH,
                 )
 
@@ -135,7 +167,8 @@ def main() -> int:
             for test_path in test_paths:
                 typer.echo(f"--\nRun pytest on {test_path}")
                 run_shell_cmd(
-                    f"{env_prefix}pytest -vv --network=local {test_path}",
+                    f"{env_prefix}pytest -vv --network=local "
+                    f"--identity={identity} {test_path}",
                     cwd=ROOT_PATH,
                 )
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,54 @@
    https://docs.pytest.org/en/latest/fixture.html
 """
 # pylint: disable=missing-function-docstring, unused-import, wildcard-import, unused-wildcard-import, line-too-long, unused-argument
+import os
+import subprocess
+from typing import Dict
 import pytest
 from icpp.conftest_base import *  # pytest fixtures provided by icpp
+from icpp.run_shell_cmd import run_shell_cmd
 
 # Define your pytest fixtures below
+
+# A second icp identity, which is NOT a controller of the canister. The
+# `test-llm-wasm` Makefile target creates it and exports the variable; the
+# default keeps a manual `pytest` run working without any setup beyond creating
+# the identity once.
+NON_CONTROLLER_IDENTITY_ENV_VAR = "ICPP_PRO_TEST_IDENTITY_NON_CONTROLLER"
+NON_CONTROLLER_IDENTITY_DEFAULT = "llama-cpp-other-user"
+
+
+@pytest.fixture(scope="session")
+def identity_non_controller(identity: str) -> Dict[str, str]:
+    """An identity that is neither a controller nor an admin of the canister.
+
+    Returns its name & principal, so a test can pass `identity=<name>` to
+    `call_canister_api` for that one call. Unlike `identity_anonymous`, this is
+    an authenticated caller, which is what proves an endpoint checks *who* the
+    caller is and not merely that they are not anonymous.
+    """
+    name = (
+        os.environ.get(NON_CONTROLLER_IDENTITY_ENV_VAR, "").strip()
+        or NON_CONTROLLER_IDENTITY_DEFAULT
+    )
+    if name == identity:
+        pytest.fail(
+            f"ERROR: ${NON_CONTROLLER_IDENTITY_ENV_VAR} is '{name}', which is the "
+            f"identity the tests already run as. It must be a different identity, "
+            f"or it would be a controller of the canister."
+        )
+
+    try:
+        principal = run_shell_cmd(
+            f"icp identity principal --identity {name}",
+            capture_output=True,
+            timeout_seconds=30,
+        ).rstrip("\n")
+    except subprocess.CalledProcessError as e:
+        pytest.fail(
+            f"ERROR: identity '{name}' does not exist. Create it with:\n\n"
+            f"    icp identity new {name} --storage plaintext\n\n"
+            f"or run the QA via `make test-llm-wasm`, which creates it.\n\n{e.output}"
+        )
+
+    return {"identity": name, "principal": principal}

--- a/test/test_admin_rbac.py
+++ b/test/test_admin_rbac.py
@@ -5,10 +5,10 @@ $ icp network start -d
 $ icp deploy -e local -y
 
 Then run the tests:
-$ pytest -vv --network local test/test_admin_rbac.py
+$ pytest -vv --network local --identity "$(icp identity default)" test/test_admin_rbac.py
 
 Or run a specific test:
-$ pytest -vv --network local test/test_admin_rbac.py::test__getAdminRoles_anonymous
+$ pytest -vv --network local --identity "$(icp identity default)" test/test_admin_rbac.py::test__getAdminRoles_anonymous
 
 """
 # pylint: disable=missing-function-docstring, unused-import, wildcard-import, unused-wildcard-import, line-too-long

--- a/test/test_cache_cleanup.py
+++ b/test/test_cache_cleanup.py
@@ -5,7 +5,7 @@ $ icpp build-wasm
 $ icp deploy -e local -y
 
 Then run the tests:
-$ pytest -vv --network local test/test_cache_cleanup.py
+$ pytest -vv --network local --identity "$(icp identity default)" test/test_cache_cleanup.py
 
 The initial-state assertion ("right after a clean deploy") is NOT in this
 file — it must be verified once before the rest of the test suite runs (see

--- a/test/test_canister_functions.py
+++ b/test/test_canister_functions.py
@@ -5,7 +5,7 @@ $ icpp build-wasm
 $ icp deploy -e local -y
 
 Then run the tests:
-$ pytest -vv --network local test/test_canister_functions.py
+$ pytest -vv --network local --identity "$(icp identity default)" test/test_canister_functions.py
 
 To run it against a deployment to the IC, just replace `local` with `production` in the commands above.
 

--- a/test/test_cycle_balance.py
+++ b/test/test_cycle_balance.py
@@ -5,7 +5,7 @@ $ icpp build-wasm
 $ icp deploy -e local -y
 
 Then run the tests:
-$ pytest -vv --network local test/test_cycle_balance.py
+$ pytest -vv --network local --identity "$(icp identity default)" test/test_cycle_balance.py
 
 Lifecycle is operator-driven (like the prompt-cache cleanup timer): the timer
 is not auto-armed, so right after a clean deploy `get_cycle_balance` returns a

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -1,11 +1,16 @@
-"""Test promptcache APIs
+"""Test the filesystem APIs
 
 First deploy the canister:
 $ icpp build-wasm
 $ icp deploy -e local -y
 
 Then run the tests:
-$ pytest -vv --network local test/test_promptcache.py
+$ pytest -vv --network local --identity "$(icp identity default)" test/test_files.py
+
+The `*_non_controller` tests call as a SECOND identity, which must not be a
+controller of the canister. It defaults to `llama-cpp-other-user` and is
+overridden with $ICPP_PRO_TEST_IDENTITY_NON_CONTROLLER. Create it once with:
+$ icp identity new llama-cpp-other-user --storage plaintext
 
 To run it against a deployment to the IC, just replace `local` with `production` in the commands above.
 
@@ -95,30 +100,30 @@ def test__recursive_dir_content_anonymous(identity_anonymous: Dict[str, str], ne
     expected_response = '(variant { Err = variant { Other = "Access Denied" } })'
     assert response == norm(expected_response)
 
-# This test requires to run the test with non-default identity --> TODO: qa script must run with non-default identity
-#
-# def test__recursive_dir_content_non_controller(identity_default: Dict[str, str], network: str) -> None:
-#     principal = identity_default["principal"]
+def test__recursive_dir_content_non_controller(identity_non_controller: Dict[str, str], network: str) -> None:
+    identity = identity_non_controller["identity"]
 
-#     response = call_canister_api(
-#         icp_yaml_path=ICP_YAML_PATH,
-#         canister_name=CANISTER_NAME,
-#         canister_method="recursive_dir_content_query",
-#         canister_argument='(record {dir = ".canister_cache"; max_entries = 0 : nat64})',
-#         network=network,
-#     )
-#     expected_response = '(variant { Err = variant { Other = "Access Denied" } })'
-#     assert response == expected_response
+    response = call_canister_api(
+        icp_yaml_path=ICP_YAML_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="recursive_dir_content_query",
+        canister_argument='(record {dir = ".canister_cache"; max_entries = 0 : nat64})',
+        network=network,
+        identity=identity,
+    )
+    expected_response = '(variant { Err = variant { Other = "Access Denied" } })'
+    assert response == norm(expected_response)
 
-#     response = call_canister_api(
-#         icp_yaml_path=ICP_YAML_PATH,
-#         canister_name=CANISTER_NAME,
-#         canister_method="recursive_dir_content_update",
-#         canister_argument='(record {dir = ".canister_cache"; max_entries = 0 : nat64})',
-#         network=network,
-#     )
-#     expected_response = '(variant { Err = variant { Other = "Access Denied" } })'
-#     assert response == expected_response
+    response = call_canister_api(
+        icp_yaml_path=ICP_YAML_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="recursive_dir_content_update",
+        canister_argument='(record {dir = ".canister_cache"; max_entries = 0 : nat64})',
+        network=network,
+        identity=identity,
+    )
+    expected_response = '(variant { Err = variant { Other = "Access Denied" } })'
+    assert response == norm(expected_response)
 
 def test__recursive_dir_content_controller(network: str, principal: str) -> None:
 
@@ -172,21 +177,21 @@ def test__filesystem_file_size_anonymous(identity_anonymous: Dict[str, str], net
     expected_response = f'(variant {{ Err = variant {{ Other = "Access Denied" }} }})'
     assert response == norm(expected_response)
 
-# This test requires to run the test with non-default identity --> TODO: qa script must run with non-default identity
-#
-# def test__filesystem_file_size_non_controller(identity_default: Dict[str, str], network: str) -> None:
-#     principal = identity_default["principal"]
-#     filename = f".canister_cache/{principal}/sessions/prompt.cache"
+def test__filesystem_file_size_non_controller(identity_non_controller: Dict[str, str], network: str) -> None:
+    identity = identity_non_controller["identity"]
+    principal = identity_non_controller["principal"]
+    filename = f".canister_cache/{principal}/sessions/prompt.cache"
 
-#     response = call_canister_api(
-#         icp_yaml_path=ICP_YAML_PATH,
-#         canister_name=CANISTER_NAME,
-#         canister_method="filesystem_file_size",
-#         canister_argument=f'(record {{filename = "{filename}"}})',
-#         network=network,
-#     )
-#     expected_response = f'(variant {{ Err = variant {{ Other = "Access Denied" }} }})'
-#     assert response == expected_response
+    response = call_canister_api(
+        icp_yaml_path=ICP_YAML_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="filesystem_file_size",
+        canister_argument=f'(record {{filename = "{filename}"}})',
+        network=network,
+        identity=identity,
+    )
+    expected_response = f'(variant {{ Err = variant {{ Other = "Access Denied" }} }})'
+    assert response == norm(expected_response)
 
 def test__filesystem_file_size_controller(network: str, principal: str) -> None:
     filename = f".canister_cache/{principal}/sessions/prompt.cache"
@@ -231,21 +236,21 @@ def test__get_creation_timestamp_ns_anonymous(identity_anonymous: Dict[str, str]
     expected_response = f'(variant {{ Err = variant {{ Other = "Access Denied" }} }})'
     assert response == norm(expected_response)
 
-# This test requires to run the test with non-default identity --> TODO: qa script must run with non-default identity
-#
-# def test__get_creation_timestamp_ns_non_controller(identity_default: Dict[str, str], network: str) -> None:
-#     principal = identity_default["principal"]
-#     filename = f".canister_cache/{principal}/sessions/prompt.cache"
+def test__get_creation_timestamp_ns_non_controller(identity_non_controller: Dict[str, str], network: str) -> None:
+    identity = identity_non_controller["identity"]
+    principal = identity_non_controller["principal"]
+    filename = f".canister_cache/{principal}/sessions/prompt.cache"
 
-#     response = call_canister_api(
-#         icp_yaml_path=ICP_YAML_PATH,
-#         canister_name=CANISTER_NAME,
-#         canister_method="get_creation_timestamp_ns",
-#         canister_argument=f'(record {{filename = "{filename}"}})',
-#         network=network,
-#     )
-#     expected_response = f'(variant {{ Err = variant {{ Other = "Access Denied" }} }})'
-#     assert response == expected_response
+    response = call_canister_api(
+        icp_yaml_path=ICP_YAML_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="get_creation_timestamp_ns",
+        canister_argument=f'(record {{filename = "{filename}"}})',
+        network=network,
+        identity=identity,
+    )
+    expected_response = f'(variant {{ Err = variant {{ Other = "Access Denied" }} }})'
+    assert response == norm(expected_response)
 
 def test__get_creation_timestamp_ns_controller(network: str, principal: str) -> None:
     filename = f".canister_cache/{principal}/sessions/prompt.cache"
@@ -290,21 +295,21 @@ def test__filesystem_remove_anonymous(identity_anonymous: Dict[str, str], networ
     expected_response = f'(variant {{ Err = variant {{ Other = "Access Denied" }} }})'
     assert response == norm(expected_response)
 
-# This test requires to run the test with non-default identity --> TODO: qa script must run with non-default identity
-# 
-# def test__filesystem_remove_non_controller(identity_default: Dict[str, str], network: str) -> None:
-#     principal = identity_default["principal"]
-#     filename = f".canister_cache/{principal}/sessions/prompt.cache"
+def test__filesystem_remove_non_controller(identity_non_controller: Dict[str, str], network: str) -> None:
+    identity = identity_non_controller["identity"]
+    principal = identity_non_controller["principal"]
+    filename = f".canister_cache/{principal}/sessions/prompt.cache"
 
-#     response = call_canister_api(
-#         icp_yaml_path=ICP_YAML_PATH,
-#         canister_name=CANISTER_NAME,
-#         canister_method="filesystem_remove",
-#         canister_argument=f'(record {{filename = "{filename}"}})',
-#         network=network,
-#     )
-#     expected_response = f'(variant {{ Err = variant {{ Other = "Access Denied" }} }})'
-#     assert response == expected_response
+    response = call_canister_api(
+        icp_yaml_path=ICP_YAML_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="filesystem_remove",
+        canister_argument=f'(record {{filename = "{filename}"}})',
+        network=network,
+        identity=identity,
+    )
+    expected_response = f'(variant {{ Err = variant {{ Other = "Access Denied" }} }})'
+    assert response == norm(expected_response)
 
 def test__filesystem_remove_controller(network: str, principal: str) -> None:
     filename = f".canister_cache/{principal}/sessions/prompt.cache"

--- a/test/test_promptcache.py
+++ b/test/test_promptcache.py
@@ -5,7 +5,7 @@ $ icpp build-wasm
 $ icp deploy -e local -y
 
 Then run the tests:
-$ pytest -vv --network local test/test_promptcache.py
+$ pytest -vv --network local --identity "$(icp identity default)" test/test_promptcache.py
 
 To run it against a deployment to the IC, just replace `local` with `production` in the commands above.
 

--- a/test/test_qwen2.py
+++ b/test/test_qwen2.py
@@ -12,7 +12,7 @@ Then upload the model:
 $ python -m scripts.upload --network local --canister llama_cpp --canister-filename models/model.gguf --filetype gguf models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/qwen2.5-0.5b-instruct-q8_0.gguf
 
 Then run the tests for this model::
-$ pytest -vv --network local test/test_qwen2.py
+$ pytest -vv --network local --identity "$(icp identity default)" test/test_qwen2.py
 
 To run it against a deployment to the IC, just replace `local` with `production` in the commands above.
 

--- a/test/test_qwen2_promptcache_deletion.py
+++ b/test/test_qwen2_promptcache_deletion.py
@@ -3,7 +3,7 @@
 Prerequisites:
 - Canister deployed and ready (`icp deploy -e local -y`).
 - Qwen2.5 gguf uploaded as `models/model.gguf` (`scripts.upload`).
-- `pytest -vv test/test_qwen2.py` was run first so the model is loaded into
+- `pytest -vv --identity "$(icp identity default)" test/test_qwen2.py` was run first so the model is loaded into
   the canister's working memory and `set_max_tokens` was called.
 
 What this file proves:
@@ -17,9 +17,9 @@ What this file proves:
 
 Run:
 
-    $ pytest -vv test/test_qwen2_promptcache_deletion.py
+    $ pytest -vv --identity "$(icp identity default)" test/test_qwen2_promptcache_deletion.py
     # (or with explicit network)
-    $ pytest -vv --network local test/test_qwen2_promptcache_deletion.py
+    $ pytest -vv --network local --identity "$(icp identity default)" test/test_qwen2_promptcache_deletion.py
 """
 
 # pylint: disable=missing-function-docstring, line-too-long

--- a/test/test_qwen3.py
+++ b/test/test_qwen3.py
@@ -8,7 +8,7 @@ coherent and contains no `<think>`/`</think>` tokens, and a multi-turn conversat
 recalls facts from earlier turns.
 
 Deploy + upload the model as `models/model.gguf`, then:
-$ pytest -vv --network local test/test_qwen3.py
+$ pytest -vv --network local --identity "$(icp identity default)" test/test_qwen3.py
 
 Notes:
 - Requires the tuned config: the canister's wasm_memory_limit is raised to 3.75 GiB

--- a/test/test_small_maxtokens.py
+++ b/test/test_small_maxtokens.py
@@ -28,7 +28,7 @@ on a real model; they do not affect the ingestion logic under test.
 Deterministic at --temp 0.0.
 
 $ SMALL_MAXTOK_MODEL=models/model.gguf SMALL_MAXTOK_KV=q8_0 SMALL_MAXTOK_CTX=512 \
-      SMALL_MAXTOK_BATCH=64 pytest -vv --network local test/test_small_maxtokens.py
+      SMALL_MAXTOK_BATCH=64 pytest -vv --network local --identity "$(icp identity default)" test/test_small_maxtokens.py
 """
 
 # pylint: disable=missing-function-docstring, line-too-long

--- a/test/test_tiny_stories.py
+++ b/test/test_tiny_stories.py
@@ -8,7 +8,7 @@ Then upload the model:
 $ python -m scripts.upload --network local --canister llama_cpp --canister-filename models/tiny.gguf --filetype gguf models/stories260Ktok512.gguf
 
 Then run the tests for this model::
-$ pytest -vv --network local test/test_tiny_stories.py
+$ pytest -vv --network local --identity "$(icp identity default)" test/test_tiny_stories.py
 
 To run it against a deployment to the IC, just replace `local` with `production` in the commands above.
 

--- a/test/test_token_counts.py
+++ b/test/test_token_counts.py
@@ -23,7 +23,7 @@ Asserted properties:
 Runs against the tiny stories model (models/tiny.gguf) deployed by
 scripts/qa_deploy_and_pytest.py; deterministic at --temp 0.0.
 
-$ pytest -vv --network local test/test_token_counts.py
+$ pytest -vv --network local --identity "$(icp identity default)" test/test_token_counts.py
 """
 
 # pylint: disable=missing-function-docstring, line-too-long


### PR DESCRIPTION
icpp-pro 6.0.0 is a breaking change: pytest must be told which icp identity to run as
(`pytest --identity <name>` or `$ICPP_PRO_TEST_IDENTITY`). It never reads or writes the
machine-wide active identity (`icp identity default`), because any other process can
change it mid-run.

## No more identity clobbering

`Makefile` used to run `icp identity default default`, which rewrote the machine-wide
active identity permanently and never restored it. That is gone. A new
`icp-test-identities` target creates two identities and exports their names:

- `llama-cpp-testing` — deploys the canister and runs the tests
- `llama-cpp-other-user` — never a controller, used by the tests below

The existence check is `icp identity principal --identity <name>`, not
`icp identity list | grep -w <name>`: grep treats `-` as a word boundary, so
`llama-cpp-testing-old` would match `llama-cpp-testing` and the identity would silently
not be created.

## Deploy and tests now agree on the controller

A canister's controller is whoever deployed it, so every step of the QA runs as the same
identity:

- `scripts/qa_deploy_and_pytest.py` resolves `$ICPP_PRO_TEST_IDENTITY` (hard-fails with
  instructions if unset) and passes `--identity` to `icp deploy`, `canister top-up`,
  `canister settings update`, and pytest.
- `scripts/ic_py_canister.py` signs as that identity when the variable is set. Only a
  controller may upload, so without this the model upload would be rejected by a canister
  the same script had just deployed.
- `scripts/2-deploy.sh` passes `--identity` when the variable is set, and is unchanged
  otherwise, so the interactive `scripts/0-all.sh` flow keeps using your active identity.

## The four TODO tests are re-enabled

`test/test_files.py` had four tests commented out, each tagged
"requires to run the test with non-default identity". 6.0.0 is what they were waiting for:
`call_canister_api(..., identity=...)` overrides the session identity for a single call.

A new `identity_non_controller` fixture in `test/conftest.py` supplies an authenticated
but unauthorized caller (name from `$ICPP_PRO_TEST_IDENTITY_NON_CONTROLLER`, default
`llama-cpp-other-user`), failing with a "create it with ..." message rather than an obscure
error. These now assert `Access Denied` for a real principal, not just for anonymous:

- `recursive_dir_content_query` / `recursive_dir_content_update`
- `filesystem_file_size`
- `get_creation_timestamp_ns`
- `filesystem_remove`

`test/test_files.py` goes from 20 to 24 passing tests.

## Docs

~15 `pytest -vv --network local ...` recipes in `test/*.py`, plus README.md,
README-qwen2.5.md, README-Release-Guide.md, CLAUDE.md and the two project skills. The test
docstrings use `--identity "$(icp identity default)"` so they stay correct for the
"deploy with your own identity" flow they document.

## Verification

`make all-tests` green locally:

- `all-static`: clang-format, black, pylint 10.00/10, mypy strict clean
- `test-llm-wasm`: 24 + 13 + 24 + 5 + 33 + 4 + 4 passed on the tiny model, 4 passed on
  gemma-3-270M (q8_0 KV) — "Congratulations, everything passed!"
- `test-llm-native`: 118/118 passed
- `icp identity default` still reports the pre-existing active identity afterwards

## Note for the vendored copies

This repo is vendored into icgpt, IConfucius, IConfucius_ai_gateway,
instruction-bounded-inference-artifact, release-verify and funnAI/PoAIW under
`llms/llama_cpp_canister/`. These changes should be carried across on the next re-vendor —
especially the four re-enabled tests.