### PR TITLE
Fix IC0502 trap: size decode batches from the context; stamp prompt-cache with the model id

### DIFF
--- a/README-qwen3-1.7B.md
+++ b/README-qwen3-1.7B.md
@@ -23,9 +23,19 @@ These are not tuning preferences — get them wrong and the canister traps:
 
 2. **Set `max_tokens_update` to 4.** A message may execute at most 40 B
    instructions (`IC0522`). The 1.7B is ~2.8× the compute of the 0.6B, so decoding
-   the 0.6B's ~8–20 tokens per call traps. Decoding **4 tokens per call** stays
-   safely under the limit — for both prompt ingestion and generation. The trade-off
-   is more `run_update` round-trips per response.
+   the 0.6B's ~8–20 tokens per call is rejected. Decoding **4 tokens per call**
+   stays safely under the limit — for both prompt ingestion and generation. The
+   trade-off is more `run_update` round-trips per response.
+
+   > **Note (fixed):** there used to be a *second*, undocumented ceiling here.
+   > `run_update` sized its decode batches from the per-call `--batch-size`
+   > default (2048) instead of the batch the persisted context was actually
+   > created with, so any `max_tokens_update` above the loaded `--batch-size`
+   > (**8** for this model) tripped
+   > `GGML_ASSERT(n_tokens_all <= cparams.n_batch)` and **trapped the canister**
+   > (`IC0502`), corrupting that caller's `prompt.cache`. Decode is now chunked
+   > at the context's real batch, so the instruction limit above is the only
+   > ceiling, and exceeding it is a clean `IC0522` rejection rather than a trap.
 
 ## Upload the gguf file
 
@@ -104,9 +114,43 @@ icp canister call llama_cpp -e local set_max_tokens '(record {
 })'
 ```
 
-`max_tokens_update = 4` is the ceiling for this model (see limit #2 above). Ingestion
-and generation both advance 4 tokens per `run_update` call, so your app must loop
-`run_update` more times per response than with the 0.6B.
+`max_tokens_update = 4` is the recommended value for this model (see limit #2
+above). Ingestion and generation both advance 4 tokens per `run_update` call, so
+your app must loop `run_update` more times per response than with the 0.6B.
+
+### Measured ceilings
+
+Probed on a local replica (same 40 B instruction limit as mainnet) with the load
+settings above — `-c 4096 --batch-size 8 --ubatch-size 8`, dual q8_0 KV — walking
+`max_tokens_update` up until the call is rejected with `IC0522`:
+
+| Phase                          | highest value that worked | first value rejected |
+| ------------------------------ | ------------------------- | -------------------- |
+| Prompt ingestion (`-p <text>`) | **8**                     | 9                    |
+| Generation (`-p ""`)           | **6**                     | 7                    |
+
+Ingestion is cheaper per token than generation, which is why its ceiling is higher.
+
+**These were measured at a short context (~20–30 tokens).** The per-token cost grows
+with the KV span, so both ceilings *shrink* as a conversation gets longer. That is
+why **4** — not the measured maximum — is the recommended setting: it has to hold for
+the whole conversation, not just the first call.
+
+If you want the extra throughput, `max_tokens_update` is a normal setting you can
+change between phases. Ingesting a long system prompt at 8 halves the round-trips:
+
+```bash
+# ingest at 8 ...
+icp canister call llama_cpp -e local set_max_tokens '(record { max_tokens_query = 1 : nat64; max_tokens_update = 8 : nat64 })'
+#   ... loop run_update with -p "<prompt>" until prompt_remaining is empty ...
+# ... then generate at 4
+icp canister call llama_cpp -e local set_max_tokens '(record { max_tokens_query = 1 : nat64; max_tokens_update = 4 : nat64 })'
+```
+
+Overshooting is now **safe to recover from**: since the batch fix in limit #2, a value
+that is too large is rejected with `IC0522` and the message is rolled back, leaving the
+prompt cache intact — so an app may probe upward and fall back on rejection. Before
+that fix, any value above the loaded `--batch-size` trapped and corrupted the cache.
 
 ## Chat — word-guessing game example
 

--- a/src/main_.cpp
+++ b/src/main_.cpp
@@ -374,6 +374,23 @@ int main_(int argc, char **argv, std::string principal_id, bool load_model_only,
   const int n_ctx_train = llama_model_n_ctx_train(model);
   const int n_ctx = llama_n_ctx(ctx);
 
+  // ICPP-PATCH-START
+  // The llama_context is Orthogonally Persisted and was created by load_model
+  // with ITS --batch-size. A run_update/run_query call does not repeat that
+  // flag, so `params.n_batch` here is common_params' 2048 default, not the
+  // batch the context actually has. Sizing a decode from params.n_batch is
+  // therefore wrong: llama_decode asserts `n_tokens_all <= cparams.n_batch`
+  // (llama-context.cpp) and a failed GGML_ASSERT does not return an error --
+  // it traps the canister (IC0502 'unreachable'), which also leaves the
+  // caller's prompt-cache file half-written.
+  // Always size batches from the context, which is the value llama_decode
+  // checks against. Same for n_ubatch, used by the non-causal assert.
+  const int n_batch_ctx = (int)llama_n_batch(ctx);
+  const int n_ubatch_ctx = (int)llama_n_ubatch(ctx);
+  LOG_INF("%s: context batch sizes: n_batch = %d, n_ubatch = %d\n", __func__,
+          n_batch_ctx, n_ubatch_ctx);
+  // ICPP-PATCH-END
+
   if (n_ctx > n_ctx_train) {
     LOG_WRN("%s: model was trained on only %d context tokens (%d specified)\n",
             __func__, n_ctx_train, n_ctx);
@@ -449,6 +466,21 @@ int main_(int argc, char **argv, std::string principal_id, bool load_model_only,
   if (!path_session.empty()) {
     LOG_INF("%s: attempting to load saved session from '%s'\n", __func__,
             path_session.c_str());
+
+    // ICPP-PATCH-START
+    // Self-heal: drop a cache this build/model cannot read, and start cold.
+    // new_chat does this too, but a caller can reach run_update without a
+    // new_chat (a model swap between calls is enough), and llama.cpp handles
+    // an unreadable session by THROWING -- which traps the canister and
+    // leaves the bad file in place, so every later call re-traps.
+    std::string stale_msg;
+    if (prompt_cache_discard_if_stale(path_session, stale_msg)) {
+      LOG_INF("%s: %s\n", __func__, stale_msg.c_str());
+      std::cout << "llama_cpp: " << std::string(__func__) << " - " << stale_msg
+                << std::endl;
+    }
+    // ICPP-PATCH-END
+
     if (!file_exists(path_session)) {
       LOG_INF("%s: session file does not exist, will create.\n", __func__);
     } else if (file_is_empty(path_session)) {
@@ -734,8 +766,10 @@ int main_(int argc, char **argv, std::string principal_id, bool load_model_only,
   LOG_INF("sampler params: \n%s\n", sparams.print().c_str());
   LOG_INF("sampler chain: %s\n", common_sampler_print(smpl).c_str());
 
+  // ICPP-PATCH: report the context's batch (what decode is actually bounded
+  // by), not params.n_batch which is the unused per-call default.
   LOG_INF("generate: n_ctx = %d, n_batch = %d, n_predict = %d, n_keep = %d\n",
-          n_ctx, params.n_batch, params.n_predict, params.n_keep);
+          n_ctx, n_batch_ctx, params.n_predict, params.n_keep);
 
   // group-attention state
   // number of grouped KV tokens so far (used only if params.grp_attn_n > 1)
@@ -978,10 +1012,13 @@ int main_(int argc, char **argv, std::string principal_id, bool load_model_only,
       // ICPP-PATCH: upstream replaced this loop with common_prompt_batch_decode,
       //             but we need per-batch control to honor the max_tokens budget
       //             and to track conversation_ss, so we keep our own eval loop.
-      for (int i = 0; i < (int)embd.size(); i += params.n_batch) {
+      for (int i = 0; i < (int)embd.size(); i += n_batch_ctx) {
         int n_eval = (int)embd.size() - i;
-        if (n_eval > params.n_batch) {
-          n_eval = params.n_batch;
+        // ICPP-PATCH: clamp to the CONTEXT's batch (see n_batch_ctx above),
+        // not params.n_batch -- exceeding it trips a GGML_ASSERT in
+        // llama_decode, which traps instead of returning an error.
+        if (n_eval > n_batch_ctx) {
+          n_eval = n_batch_ctx;
         }
 
         // ICPP-PATCH-START
@@ -1039,8 +1076,12 @@ int main_(int argc, char **argv, std::string principal_id, bool load_model_only,
           // next call reloads the same short prefix and ingestion never
           // advances (prompt_remaining stalls). prompt_cache_ro still opts out.
           if (!path_session.empty() && !params.prompt_cache_ro) {
-            session_tokens.insert(session_tokens.end(), embd.begin(),
-                                  embd.begin() + n_eval);
+            // Append THIS chunk: [i, i + n_eval). embd holds at most one batch
+            // (see the n_batch_ctx cap on the fill loop), so i is 0 today, but
+            // offsetting by i keeps the append correct — and the cache
+            // uncorrupted — if embd ever spans more than one chunk.
+            session_tokens.insert(session_tokens.end(), embd.begin() + i,
+                                  embd.begin() + i + n_eval);
             n_session_consumed = session_tokens.size();
           }
           break_while_loop = true;
@@ -1111,7 +1152,11 @@ int main_(int argc, char **argv, std::string principal_id, bool load_model_only,
                               /* accept_grammar= */ false);
 
         ++n_consumed;
-        if ((int)embd.size() >= params.n_batch) {
+        // ICPP-PATCH: bound by the CONTEXT's batch (see n_batch_ctx above), not
+        // params.n_batch. This keeps embd at most one batch, so the decode loop
+        // below always runs a single chunk (i == 0) and every decoded token is
+        // appended to session_tokens.
+        if ((int)embd.size() >= n_batch_ctx) {
           break;
         }
 
@@ -1412,6 +1457,11 @@ int main_(int argc, char **argv, std::string principal_id, bool load_model_only,
         path_session.c_str());
     llama_state_save_file(ctx, path_session.c_str(), session_tokens.data(),
                           session_tokens.size());
+    // ICPP-PATCH: (re)stamp the sidecar so it always describes the file we
+    // just wrote, with the model that wrote it. Without this, a cache the
+    // load above discarded would be re-created unstamped and discarded again
+    // on every subsequent call -- a permanent cold start.
+    prompt_cache_write_format_stamp(path_session);
   }
 
   LOG("\n\n");

--- a/src/promptcache.cpp
+++ b/src/promptcache.cpp
@@ -12,6 +12,7 @@
 #include "utils.h"
 
 #include "arg.h"
+#include "llama.h" // llama_model_desc, for the model-identity stamp
 #include "log.h"
 
 #include <filesystem>
@@ -47,6 +48,19 @@ prompt_cache_stamp_path(const std::string &canister_path_session) {
   return canister_path_session + ".icppfmt";
 }
 
+std::string prompt_cache_model_id() {
+  // Identity of the currently loaded model, e.g. "qwen3 1.7B Q4_K_M".
+  // Empty when no model is loaded yet (g_model is set by main_ at load_model).
+  if (g_model == nullptr || *g_model == nullptr) return "";
+
+  char buf[256];
+  buf[0] = '\0';
+  // snprintf semantics: the return value is the length the description WOULD
+  // have, so read the (always NUL-terminated) buffer instead of trusting it.
+  llama_model_desc(*g_model, buf, sizeof(buf));
+  return std::string(buf);
+}
+
 bool prompt_cache_format_is_current(const std::string &canister_path_session) {
   const std::string stamp_path = prompt_cache_stamp_path(canister_path_session);
 
@@ -55,7 +69,19 @@ bool prompt_cache_format_is_current(const std::string &canister_path_session) {
 
   std::string stamp;
   std::getline(f, stamp);
-  return stamp == PROMPT_CACHE_FORMAT;
+  if (stamp != PROMPT_CACHE_FORMAT) return false;
+
+  // Second line: the model the cache was written with. A cache is only valid
+  // for the model that produced it -- see prompt_cache_discard_if_stale.
+  // Absent (older stamp) counts as a mismatch, so those caches are discarded.
+  std::string stamped_model;
+  if (!std::getline(f, stamped_model)) return false;
+
+  const std::string current_model = prompt_cache_model_id();
+  // No model loaded => nothing to compare against; do not discard on that basis.
+  if (current_model.empty()) return true;
+
+  return stamped_model == current_model;
 }
 
 void prompt_cache_write_format_stamp(const std::string &canister_path_session) {
@@ -63,6 +89,7 @@ void prompt_cache_write_format_stamp(const std::string &canister_path_session) {
                   std::ios::trunc);
   if (f.is_open()) {
     f << PROMPT_CACHE_FORMAT << std::endl;
+    f << prompt_cache_model_id() << std::endl;
   }
 }
 
@@ -72,15 +99,26 @@ bool prompt_cache_discard_if_stale(const std::string &canister_path_session,
   if (!std::filesystem::exists(canister_path_session)) return false;
   if (prompt_cache_format_is_current(canister_path_session)) return false;
 
-  // Written by an older llama.cpp. llama.cpp would ACCEPT it (same magic and
-  // version) and then misparse it, so delete it rather than let that happen.
+  // Two ways a cache becomes unusable, both of which llama.cpp handles by
+  // throwing -- and in this canister a throw is a TRAP (IC0503), which also
+  // leaves the half-read cache in place so every later call re-traps:
+  //
+  //  (-) written by an older llama.cpp: b4531 and b10076 share magic 'ggsn'
+  //      and version 9, so llama.cpp ACCEPTS the file and then misparses it.
+  //  (-) written with a different model: llama_context::state_read_data
+  //      compares the serialized arch against the loaded model and throws
+  //      "wrong model arch: 'llama' instead of 'qwen3'". Comparing the full
+  //      model description also catches same-arch/different-size swaps
+  //      (e.g. Qwen3-0.6B -> Qwen3-1.7B), which the arch check alone misses.
+  //
+  // Either way: delete it and start cold. That is recoverable; a trap is not.
   std::error_code ec;
   std::filesystem::remove(canister_path_session, ec);
   std::filesystem::remove(prompt_cache_stamp_path(canister_path_session), ec);
 
-  msg = "Discarded prompt-cache file written by an older llama.cpp build "
-        "(incompatible session format): " +
-        canister_path_session;
+  msg = "Discarded prompt-cache file that was not written by this build with "
+        "the currently loaded model (" +
+        prompt_cache_model_id() + "): " + canister_path_session;
   return true;
 }
 

--- a/src/promptcache.h
+++ b/src/promptcache.h
@@ -18,10 +18,21 @@ bool get_canister_path_session(const std::string &path_session,
 // A cache written by the old build therefore PASSES llama.cpp's check and is
 // then misparsed -- silently, with no error.
 //
-// So we stamp each cache with our own format generation, in a sidecar file
-// "<cache>.icppfmt", and discard any cache that is unstamped or mismatched.
-// Bump PROMPT_CACHE_FORMAT whenever a llama.cpp upgrade changes the session
-// serialization.
+// The same applies to the MODEL: a cache is only valid for the model that
+// wrote it. llama_context::state_read_data compares the serialized arch with
+// the loaded model and THROWS on a mismatch ("wrong model arch: 'llama'
+// instead of 'qwen3'"), and in this canister a throw is a trap -- which also
+// leaves the offending cache in place, so every later call re-traps.
+//
+// So we stamp each cache with our own format generation AND the model it was
+// written with, in a sidecar file "<cache>.icppfmt" (line 1 = format,
+// line 2 = model description), and discard any cache that is unstamped or
+// mismatched. Bump PROMPT_CACHE_FORMAT whenever a llama.cpp upgrade changes
+// the session serialization.
+
+// Description of the currently loaded model, e.g. "qwen3 1.7B Q4_K_M".
+// Empty string when no model is loaded.
+std::string prompt_cache_model_id();
 
 bool prompt_cache_format_is_current(const std::string &canister_path_session);
 void prompt_cache_write_format_stamp(const std::string &canister_path_session);


### PR DESCRIPTION
Two reproducible canister traps, both found while investigating the Qwen3-1.7B
generation traps. In this canister a trap is not a recoverable error: it aborts the
message AND leaves the caller's `prompt.cache` half-written, so every later call for
that principal re-traps until the cache is cleaned up.

## 1. Decode batches were sized from the wrong `n_batch` (IC0502 `unreachable`)

`main_.cpp` sized its decode batches from `params.n_batch` — parsed from the
*current call's* args — while `llama_decode` asserts against the **persisted
context's** `cparams.n_batch`. The `llama_context` is Orthogonally Persisted and was
created by `load_model` with its own `--batch-size`; a `run_update` call never
repeats that flag, so `params.n_batch` was `common_params`' 2048 default. The clamp

```cpp
if (n_eval > params.n_batch) { n_eval = params.n_batch; }   // clamps to 2048
```

was therefore dead code — clamping to 2048 against a real limit of 8. The only thing
accidentally holding the line was `max_tokens`.

Exceeding it fails `GGML_ASSERT(n_tokens_all <= cparams.n_batch)`
(`llama-context.cpp:1761`), and a failed assert does not return an error — it traps:

```
llama-context.cpp:1761: GGML_ASSERT(n_tokens_all <= cparams.n_batch) failed
[TRAP]: unreachable
```

So any `max_tokens_update` greater than the loaded `--batch-size` trapped the
canister. Every model in the repo happened to sit under its own limit
(Qwen3-1.7B 4<8, Qwen3-0.6B 20<64, gemma 44<64), which is why this was never hit.

**Fix:** derive the batch from the context with `llama_n_batch(ctx)` and use it for
the decode clamp, the loop stride, and the prompt-fill bound. Also offset the
session-token append by `i`; with the fill capped at one batch that path is
single-chunk today, but the un-offset `embd.begin()` would silently corrupt the
prompt cache if it ever spanned chunks.

| `max_tokens=40`, `--batch-size 8` | |
| --- | --- |
| before | `IC0502` trap, prompt cache corrupted |
| after  | `IC0522` instruction limit — clean rejection, state rolled back |

## 2. A prompt-cache from another model traps (IC0503)

`llama_context::state_read_data` compares the serialized arch against the loaded
model and **throws** on a mismatch (`llama-context.cpp:3157`). In this canister a
throw is a trap:

```
UNCAUGHT C++ EXCEPTION [St13runtime_error]: wrong model arch: 'llama' instead of 'qwen3'
```

The `.icppfmt` sidecar stamped only the format generation, not the model — and the
staleness check ran **only in `new_chat`**, while `run_update` -> `main_()` loaded the
session unchecked. A model swap between calls was enough to re-trap forever.

**Fix:**
- stamp the model identity (`llama_model_desc`, e.g. `qwen3 1.7B Q4_K_M`) on line 2
  of the sidecar. Matching the full description also catches same-arch/different-size
  swaps (Qwen3-0.6B -> Qwen3-1.7B) that llama.cpp's arch-only check misses;
- move the discard into `main_()`, before `llama_state_load_file`, so `run_update`
  self-heals — this is the "discard the cache and start cold instead of re-trapping"
  behaviour that was missing;
- re-stamp after `llama_state_save_file`, otherwise a cache discarded inside `main_()`
  would be re-created unstamped and discarded again on every call — a permanent cold
  start.

Verified live with a real model swap and no `new_chat`: trap -> clean `Ok` cold start
(`cached=0, decoded=4`), and the next call reuses the new cache (`cached=4`).

## Measured `max_tokens` ceilings (README-qwen3-1.7B.md)

Probed on a local replica (same 40 B limit as mainnet), Qwen3-1.7B Q4_K_M at
`-c 4096 --batch-size 8`, dual q8_0 KV:

| phase | highest working | first rejected |
| --- | --- | --- |
| ingestion | 8 | 9 |
| generation | 6 | 7 |

Generation tops out at 6 — below the old batch cap of 8, so the batch bug was never
the binding constraint there and `max_tokens_update = 4` was correctly chosen.
Ingestion sustains 8, i.e. 2x the documented value, and can be raised for the ingest
phase alone. Both were measured at short context and shrink as the KV span grows,
which is why 4 stays the recommended single value. The README now records this, plus
the fact that overshooting is now a recoverable `IC0522` rather than a trap.

## Verification

- `make all-tests` green: `all-static`, the full wasm QA (all pytest suites incl.
  `test_promptcache.py`, `test_files.py`, `test_small_maxtokens.py`), and
  `test-llm-native` **118/118 passed**
- Qwen3-1.7B on a local canister at `-c 4096`: 5 ingest + 6 generate calls, no trap,
  coherent output, heap flat at 1.340 GiB
- the two traps above reproduced before the fix and confirmed gone after

## Not addressed

The mainnet `heap out of bounds` during long generation (bug 2 of the TMP note) is a
*different* fault from the two fixed here and is not yet reproduced. Useful datum:
34 generation calls / 136 generated tokens produced no trap, past the ~108 reported —
so it tracks total session length rather than generated-token count, pointing at the
`n_kv` 256-token padding boundary (`llama-kv-cache.cpp:1232`). The `load_model`
IC0522 at `-c 16384` (bug 1) is also untouched.