### PR TITLE
Fix prompt-cache stamp lifecycle (copy/remove/upload); add upgrade regression tests

### DIFF
--- a/README-contributors-guide.md
+++ b/README-contributors-guide.md
@@ -107,6 +107,131 @@ is clean but the IC traps, suspect the DEPLOY PIPELINE (stale `.icp/cache` cache
 not the binary. In b10076, a multi-hour "install trap" chase was ultimately the deploy pipeline installing a
 stale cached wasm.
 
+## Two classes of bug that upstream does NOT have — re-check both on every upgrade
+
+These are not llama.cpp bugs, so there is nothing to send upstream. They exist only because
+of two things this canister does that `llama-cli` never does. Both produced canister traps
+that were found and fixed in v0.16.2; new upstream code can reintroduce either at any time,
+so walk the checklists below on each upgrade.
+
+### 1. Upstream's `try`/`catch` error handling is DEAD here — a throw is a trap
+
+`src/wasi-exception-stubs.cpp` makes `__cxa_throw` call `IC_API::trap()` and
+`__cxa_begin_catch`/`__cxa_end_catch` no-ops. So **every upstream API whose contract is
+"catch internally, return an error code" instead traps the canister**, and the trap also
+rolls back the whole message.
+
+Real example (fixed in v0.16.2): `llama_state_load_file` wraps its call in `try`/`catch` and
+returns `false` on a bad session file (`llama-context.cpp`, look for
+`catch (const std::exception & err)`). Upstream `main.cpp` therefore reports a clean error
+when a prompt cache was written by a different model. In the canister the same path threw
+`wrong model arch: 'llama' instead of 'qwen3'` and trapped (`IC0503`) — and, because the bad
+cache stayed on disk, every later call for that principal re-trapped.
+
+**On each upgrade:** re-run this and check every hit that we call, because upstream adds
+new ones:
+
+```bash
+grep -n -B8 "catch (const std::exception" src/llama_cpp_onicai_fork/src/llama-context.cpp
+```
+
+At b10076 the catch-and-return-error entry points are `llama_state_load_file`,
+`llama_state_save_file`, `llama_state_seq_save_file`, `llama_state_seq_load_file`, and
+`llama_context::state_{get_size,get_data,set_data}`. We call `llama_state_save_file` on
+**every** `run_update`. For any such API we call, validate the precondition BEFORE calling in
+(as `prompt_cache_discard_if_stale()` now does), rather than relying on the return value.
+
+A useful corollary for diagnosis: a C++ throw surfaces as **`IC0503`** with an
+`UNCAUGHT C++ EXCEPTION [type]: message` payload, whereas a failed `GGML_ASSERT` or a real
+memory fault surfaces as **`IC0502`**. The error code alone tells you which class you are in.
+
+### 2. The `llama_context` outlives the `common_params` that created it
+
+`load_model` builds the context once and it is Orthogonally Persisted; every later
+`run_update`/`run_query` re-parses a **different** argv that does not repeat the load-time
+flags. So in `src/main_.cpp` any `params.<x>` that upstream implicitly assumes equals the
+context's `cparams.<x>` is **stale — it is the `common_params` default**, not what the
+context has.
+
+Upstream cannot hit this: `common_init_from_params` copies `params` into `cparams`
+(`common/common.cpp`, e.g. `cparams.n_batch = params.n_batch`) in the same process, so the two
+can never diverge there.
+
+Real example (fixed in v0.16.2): the decode loop clamped `n_eval` to `params.n_batch` — the
+2048 default — while `llama_decode` asserts `n_tokens_all <= cparams.n_batch`, which was 8
+(`--batch-size 8` at load). The clamp was dead code, and any `max_tokens_update` above the
+loaded `--batch-size` failed `GGML_ASSERT` and trapped (`IC0502 unreachable`).
+
+**On each upgrade:** after re-porting `main_.cpp`, audit every `params.` read in it and ask
+"is this a load-time property of the context?". If it is, take it from the context instead:
+
+```bash
+grep -n "params\." src/main_.cpp
+```
+
+The context-owned properties, and the `common_params` field each is copied from at load time
+(`common/common.cpp`, `common_init_from_params`) — read the LEFT column in `main_.cpp`, never
+the right:
+
+| take this from the context | NOT this per-call field |
+| -------------------------- | ----------------------- |
+| `llama_n_ctx(ctx)`         | `params.n_ctx`          |
+| `llama_n_batch(ctx)`       | `params.n_batch`        |
+| `llama_n_ubatch(ctx)`      | `params.n_ubatch`       |
+| `llama_n_seq_max(ctx)`     | `params.n_parallel`     |
+
+(`main_.cpp` already reads `n_ctx` correctly — it was only the batch sizes that were wrong.)
+Sampling settings, the prompt-cache path and the other per-call flags are genuinely per-call
+and must keep coming from `params`.
+
+### 3. The v0.16.2 fixes live in `main_.cpp` — RE-APPLY them after the re-port
+
+`src/main_.cpp` is a **port of upstream's** `tools/completion/completion.cpp`, re-done on
+every upgrade (see "C5 — the `main_.cpp` re-port" in `README-0003-305ba519.md`). It carries
+~93 `ICPP-PATCH` markers, and patches HAVE been lost in a re-port before — b10076's Bug #3
+(`use_mmap`) and Bug #4 (warmup) were both silently dropped in the merge and only resurfaced
+as runtime traps on the replica.
+
+So the fixes for the two classes above are **not** self-sustaining:
+
+| File | Survives a re-port? |
+| ---- | ------------------- |
+| `src/promptcache.{h,cpp}` | **Yes** — canister-owned, no upstream equivalent |
+| `src/main_.cpp` | **No** — re-ported from upstream; every `ICPP-PATCH` must be re-applied |
+
+The five edits in `main_.cpp` to re-apply, all marked `ICPP-PATCH`:
+
+| # | What | Why it must come back |
+| - | ---- | --------------------- |
+| 1 | Define `n_batch_ctx` / `n_ubatch_ctx` from `llama_n_batch(ctx)` / `llama_n_ubatch(ctx)`, next to `const int n_ctx = llama_n_ctx(ctx);` | the single source for 2-4 below |
+| 2 | Decode loop: stride `i += n_batch_ctx` and clamp `n_eval > n_batch_ctx` (upstream uses `params.n_batch` in both) | oversized batch ⇒ `GGML_ASSERT` ⇒ `IC0502` trap |
+| 3 | Prompt-fill loop: break at `embd.size() >= n_batch_ctx` (upstream: `params.n_batch`) | keeps `embd` to one batch so the decode loop is single-chunk |
+| 4 | `max_tokens` break: append `[embd.begin() + i, embd.begin() + i + n_eval)` (not from `begin()`) | wrong offset silently corrupts the prompt cache if `embd` ever spans chunks |
+| 5 | Call `prompt_cache_discard_if_stale()` before `llama_state_load_file`, and `prompt_cache_write_format_stamp()` after `llama_state_save_file` | without the first, a foreign cache traps; without the second, a discarded cache cold-starts forever |
+
+Verify after the re-port — all of these must return hits:
+
+```bash
+grep -n "n_batch_ctx" src/main_.cpp                      # items 1-3: expect ~10 hits
+grep -n "embd.begin() + i" src/main_.cpp                 # item 4:    expect 3 hits
+grep -n "prompt_cache_discard_if_stale\|prompt_cache_write_format_stamp" \
+        src/main_.cpp                                    # item 5:    expect 2 hits
+# and the inverse -- params.n_batch must survive only in COMMENTS, never in code:
+grep -n "params\.n_batch" src/main_.cpp | grep -v "//"   # expect NO output
+```
+
+⚠️ **Neither fix has an automated regression test yet**, so these greps are currently the only
+guard — a lost patch will not fail `make all-tests`, it will trap on the replica. Two cheap
+end-to-end checks that do catch them:
+
+```bash
+# item 2/3: max_tokens ABOVE the loaded --batch-size must give a clean IC0522, never a trap
+#   load with --batch-size 8, set_max_tokens update=40, then run_update with a prompt
+# item 5: a prompt cache from another model must self-heal, not trap
+#   load model A -> new_chat + run_update -> load model B -> run_update on the SAME cache
+#   expect Ok with n_prompt_tokens_cached = 0 (cold start), not a trap
+```
+
 ## Branch management
 
 We need to rethink this logic, but for now it is ok...

--- a/scripts/qa_deploy_and_pytest.py
+++ b/scripts/qa_deploy_and_pytest.py
@@ -85,6 +85,10 @@ def main() -> int:
                     "test/test_token_counts.py",
                     # small-max_tokens multi-call ingestion regression (f16 KV).
                     "test/test_small_maxtokens.py",
+                    # Guards the two bug classes a llama.cpp upgrade re-introduces
+                    # (lost ICPP-PATCHes in main_.cpp). MUST stay last: it
+                    # reloads the model with a deliberately small --batch-size.
+                    "test/test_upgrade_regressions.py",
                 ],
             },
             # gemma-3-270M (gemma3 / iSWA architecture, q8_0 KV): exercises the

--- a/src/promptcache.cpp
+++ b/src/promptcache.cpp
@@ -84,6 +84,34 @@ bool prompt_cache_format_is_current(const std::string &canister_path_session) {
   return stamped_model == current_model;
 }
 
+void prompt_cache_remove_stamp(const std::string &canister_path_session) {
+  // Drop the sidecar so the cache counts as UNSTAMPED and will be discarded.
+  // Must be called by anything that removes or overwrites the cache bytes:
+  // a stamp that outlives the file it describes is worse than no stamp at all,
+  // because prompt_cache_discard_if_stale() would then vouch for content this
+  // build never wrote and llama.cpp would trap on it.
+  if (canister_path_session.empty()) return;
+  std::error_code ec;
+  std::filesystem::remove(prompt_cache_stamp_path(canister_path_session), ec);
+}
+
+void prompt_cache_copy_stamp(const std::string &from_session,
+                             const std::string &to_session) {
+  // The stamp describes the BYTES, so it must travel with them. A cache copied
+  // from another of this caller's caches really was written by this build with
+  // this model, so its stamp stays valid and the restored cache stays warm.
+  // (Without this, save/restore via copy_prompt_cache silently degrades into a
+  // cold start on every restore.)
+  const std::string from_stamp = prompt_cache_stamp_path(from_session);
+  const std::string to_stamp = prompt_cache_stamp_path(to_session);
+
+  std::error_code ec;
+  std::filesystem::remove(to_stamp, ec);
+  if (std::filesystem::exists(from_stamp)) {
+    std::filesystem::copy(from_stamp, to_stamp, ec);
+  }
+}
+
 void prompt_cache_write_format_stamp(const std::string &canister_path_session) {
   std::ofstream f(prompt_cache_stamp_path(canister_path_session),
                   std::ios::trunc);
@@ -199,6 +227,9 @@ void remove_prompt_cache() {
     // Remove the file if it exists
     if (std::filesystem::exists(path_session)) {
       bool success = std::filesystem::remove(path_session);
+      // Never leave the stamp behind: it would vouch for whatever bytes appear
+      // at this path next (e.g. an uploaded cache from another build/model).
+      prompt_cache_remove_stamp(path_session);
       if (success) {
         msg = "Cache file " + path_session + " deleted successfully";
       } else {
@@ -290,6 +321,11 @@ void copy_prompt_cache() {
     return;
   }
 
+  // The format/model stamp describes the bytes we just copied, so carry it
+  // across. Without this the restored cache is unstamped, gets discarded on
+  // first use, and the save/restore workflow silently loses its warm cache.
+  prompt_cache_copy_stamp(from_path, to_path);
+
   CandidTypeRecord status_code_record;
   status_code_record.append("status_code", CandidTypeNat16{200});
   ic_api.to_wire(CandidTypeVariant{"Ok", status_code_record});
@@ -361,6 +397,12 @@ void upload_prompt_cache_chunk() {
         "Err", CandidTypeVariant{"Other", CandidTypeText{error_msg}}});
     return;
   }
+
+  // The uploaded bytes did not come from this canister, so any existing stamp
+  // no longer describes this file. Drop it: the cache is then treated as
+  // unstamped and discarded on first use (a cold start), instead of being
+  // handed to llama.cpp, which traps on a session it cannot parse.
+  prompt_cache_remove_stamp(filename);
 
   file_upload_chunk_(ic_api, filename, v, chunksize, offset);
 }

--- a/src/promptcache.h
+++ b/src/promptcache.h
@@ -37,6 +37,19 @@ std::string prompt_cache_model_id();
 bool prompt_cache_format_is_current(const std::string &canister_path_session);
 void prompt_cache_write_format_stamp(const std::string &canister_path_session);
 
+// Drop the stamp, so the cache counts as unstamped and is discarded on next
+// use. MUST be called by anything that removes or overwrites the cache bytes
+// (remove_prompt_cache, upload_prompt_cache_chunk): a stamp that outlives the
+// file it describes vouches for content this build never wrote, and llama.cpp
+// then traps on it.
+void prompt_cache_remove_stamp(const std::string &canister_path_session);
+
+// Carry the stamp along when the cache BYTES are copied (copy_prompt_cache).
+// The copied cache really was written by this build with this model, so it
+// stays valid — without this, save/restore silently degrades to a cold start.
+void prompt_cache_copy_stamp(const std::string &from_session,
+                             const std::string &to_session);
+
 // If a cache exists but was not written by this build, delete it (and its
 // sidecar) so a fresh one is created. Returns true if something was discarded;
 // `msg` describes what happened.

--- a/test/test_upgrade_regressions.py
+++ b/test/test_upgrade_regressions.py
@@ -1,0 +1,418 @@
+"""Regression tests for the two bug classes that a llama.cpp upgrade re-introduces.
+
+READ THIS BEFORE DELETING OR WEAKENING A TEST HERE.
+
+`src/main_.cpp` is a PORT of upstream's `tools/completion/completion.cpp` and is
+re-done on every llama.cpp upgrade. It carries ~93 `ICPP-PATCH` markers, and
+patches have been silently dropped in a re-port before (b10076 lost the
+`use_mmap` and warmup patches — see README-0003-305ba519.md, Bugs #3/#4). Those
+losses only surfaced as runtime traps on a replica, long after `make
+test-llm-native` was green.
+
+The two classes, both documented in README-contributors-guide.md
+("Two classes of bug that upstream does NOT have"):
+
+  1. Upstream's try/catch error handling is DEAD in the canister. The WASI
+     exception shim makes `throw` a trap and `catch` a no-op, so an upstream API
+     whose contract is "catch internally, return an error code" TRAPS instead.
+  2. The llama_context outlives the common_params that created it. Any
+     `params.<x>` that upstream assumes equals the context's `cparams.<x>` is
+     stale here — it is the common_params default, not what the context has.
+
+WHY THESE LIVE IN PYTEST AND NOT IN native/:
+The native build cannot reproduce either failure. Native has working exceptions
+(so class 1 degrades to a clean Err instead of a trap) and no instruction limit.
+Only the deployed wasm on a replica has the shim and the trap semantics these
+tests assert on. A green native suite proves nothing here.
+
+This file loads the model itself, with a deliberately SMALL --batch-size, so it
+must run last in a QA iteration (see scripts/qa_deploy_and_pytest.py).
+
+$ pytest -vv --network local --identity "$(icp identity default)" test/test_upgrade_regressions.py
+"""
+
+# pylint: disable=missing-function-docstring, line-too-long
+
+import re
+from pathlib import Path
+
+from .candid_compat import call_canister_api
+
+ICP_YAML_PATH = Path(__file__).parent / "../icp.yaml"
+CANISTER_NAME = "llama_cpp"
+
+MODEL = "models/tiny.gguf"
+
+# The whole point: load with a batch far below the max_tokens used later, so the
+# context's n_batch and common_params' 2048 default are unmistakably different.
+LOAD_BATCH = 8
+LOAD_CTX = 512
+
+# > LOAD_BATCH, so a decode sized from params.n_batch would exceed the context's
+# batch and trip GGML_ASSERT(n_tokens_all <= cparams.n_batch).
+MAX_TOKENS_ABOVE_BATCH = 40
+
+CACHE_BATCH = "upgrade_regr_batch/prompt.cache"
+CACHE_FOREIGN = "upgrade_regr_foreign/prompt.cache"
+# Save/restore + branch caches, for the copy_prompt_cache tests.
+CACHE_LIVE = "upgrade_regr_copy/prompt.cache"
+CACHE_SAVE = "upgrade_regr_copy/prompt-save.cache"
+CACHE_BRANCH = "upgrade_regr_copy/prompt-branch.cache"
+
+# Ingested once, then re-sent to read back how much of it is served from cache.
+WARM_PROMPT = "Joe loves writing stories and poems"
+
+# Tokenizes to well over LOAD_CTX tokens on any vocab.
+LONG_PROMPT = "the quick brown fox jumps over the lazy dog and then runs away " * 40
+
+# Markers of a canister TRAP, as surfaced by icp when a call is rejected.
+# IC0502 = failed GGML_ASSERT / memory fault, IC0503 = uncaught C++ exception.
+TRAP_MARKERS = (
+    "IC0502",
+    "IC0503",
+    "heap out of bounds",
+    "unreachable",
+    "Canister trapped",
+    "UNCAUGHT C++ EXCEPTION",
+)
+
+
+def _call(network: str, method: str, arg: str) -> str:
+    return call_canister_api(
+        icp_yaml_path=ICP_YAML_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method=method,
+        canister_argument=arg,
+        network=network,
+    )
+
+
+def _assert_no_trap(response: str, what: str) -> None:
+    """A trap is never acceptable: it rolls back the message AND leaves the
+    caller's prompt.cache half-written, so every later call re-traps."""
+    for marker in TRAP_MARKERS:
+        assert marker not in response, (
+            f"{what} TRAPPED (marker {marker!r}).\n"
+            f"An ICPP-PATCH in src/main_.cpp was most likely lost in a re-port — "
+            f"see README-contributors-guide.md, "
+            f"'The v0.16.2 fixes live in main_.cpp — RE-APPLY them'.\n"
+            f"{response}"
+        )
+
+
+def _cached(response: str) -> int:
+    match = re.search(r"n_prompt_tokens_cached = opt \(([\d_]+) : nat64\)", response)
+    assert match, f"n_prompt_tokens_cached missing: {response}"
+    return int(match.group(1).replace("_", ""))
+
+
+def _decoded(response: str) -> int:
+    match = re.search(r"n_prompt_tokens_decoded = opt \(([\d_]+) : nat64\)", response)
+    assert match, f"n_prompt_tokens_decoded missing: {response}"
+    return int(match.group(1).replace("_", ""))
+
+
+def _field(response: str, name: str) -> str:
+    match = re.search(rf'{name} = "((?:[^"\\]|\\.)*)"', response)
+    return match.group(1) if match else ""
+
+
+def _copy_cache(network: str, from_cache: str, to_cache: str) -> str:
+    return _call(
+        network,
+        "copy_prompt_cache",
+        f'(record {{ from = "{from_cache}"; to = "{to_cache}" }})',
+    )
+
+
+def _ingest_fully(network: str, cache: str, prompt: str) -> None:
+    """Loop run_update until the whole prompt is in the cache."""
+    for _ in range(30):
+        resp = _run(network, cache, prompt, "1")
+        _assert_no_trap(resp, "run_update during ingestion")
+        assert "(variant { Ok" in resp, resp
+        if _field(resp, "prompt_remaining") == "":
+            return
+    raise AssertionError(f"prompt never fully ingested into {cache}")
+
+
+def _warm_reading(network: str, cache: str, prompt: str) -> int:
+    """Re-send an already-ingested prompt; returns how many tokens were served
+    from the cache. Decoding ANY of them means the cache was not reused."""
+    resp = _run(network, cache, prompt, "1")
+    _assert_no_trap(resp, "warm-cache reading")
+    assert "(variant { Ok" in resp, resp
+    assert _decoded(resp) == 0, (
+        f"{_decoded(resp)} prompt tokens had to be re-ingested, so the cache was "
+        f"NOT reused (a silent cold start).\n{resp}"
+    )
+    return _cached(resp)
+
+
+def _set_max_tokens(network: str, value: int) -> str:
+    return _call(
+        network,
+        "set_max_tokens",
+        f"(record {{ max_tokens_query = 1 : nat64; max_tokens_update = {value} : nat64 }})",
+    )
+
+
+def _run(network: str, cache: str, prompt: str, n: str) -> str:
+    return _call(
+        network,
+        "run_update",
+        '(record { args = vec {"--prompt-cache"; "'
+        + cache
+        + '"; "--prompt-cache-all"; "--samplers"; "temperature"; "--temp"; "0.0"'
+        + '; "-p"; "'
+        + prompt
+        + '"; "-n"; "'
+        + n
+        + '"} })',
+    )
+
+
+def test__load_model_with_small_batch(network: str) -> None:
+    """Load with an explicitly small batch — the precondition for everything below."""
+    resp = _call(
+        network,
+        "load_model",
+        '(record { args = vec {"--model"; "'
+        + MODEL
+        + f'"; "-c"; "{LOAD_CTX}"; "--batch-size"; "{LOAD_BATCH}"; "--ubatch-size"; "{LOAD_BATCH}"'
+        + "} })",
+    )
+    _assert_no_trap(resp, "load_model")
+    assert "(variant { Ok" in resp, resp
+
+
+# ---------------------------------------------------------------------------
+# Class 2: the context outlives the params that created it.
+# Guards ICPP-PATCH items 1-3 (n_batch_ctx) in src/main_.cpp.
+# ---------------------------------------------------------------------------
+def test__max_tokens_above_loaded_batch_does_not_trap(network: str) -> None:
+    """max_tokens > the loaded --batch-size must NOT trap.
+
+    Before the fix, main_.cpp clamped n_eval to `params.n_batch` (the 2048
+    common_params default) while llama_decode asserts against the context's
+    `cparams.n_batch` (LOAD_BATCH). The clamp was dead code, so any
+    max_tokens_update above the loaded batch tripped
+    `GGML_ASSERT(n_tokens_all <= cparams.n_batch)` -> IC0502 'unreachable'.
+
+    Decode is now chunked at llama_n_batch(ctx), so this is either a normal Ok
+    or — if the model/host is slow enough — a clean IC0522 instruction-limit
+    rejection. Never a trap.
+    """
+    assert "Ok" in _set_max_tokens(network, MAX_TOKENS_ABOVE_BATCH)
+    _call(
+        network,
+        "remove_prompt_cache",
+        f'(record {{ args = vec {{"--prompt-cache"; "{CACHE_BATCH}"}} }})',
+    )
+    assert "Ok" in _call(
+        network,
+        "new_chat",
+        f'(record {{ args = vec {{"--prompt-cache"; "{CACHE_BATCH}"}} }})',
+    )
+
+    resp = _run(network, CACHE_BATCH, "Joe loves writing stories and poems and songs every single day of the week", "1")
+    _assert_no_trap(resp, f"run_update with max_tokens={MAX_TOKENS_ABOVE_BATCH} > batch={LOAD_BATCH}")
+    # The tiny model decodes this well inside the instruction limit, so it must
+    # actually succeed rather than merely "not trap".
+    assert "(variant { Ok" in resp, resp
+
+    _set_max_tokens(network, 4)
+
+
+def test__ctx_size_is_taken_from_the_context_not_params(network: str) -> None:
+    """The prompt-too-long guard must use the LOADED ctx, not params.n_ctx.
+
+    A second instance of class 2, and a canary for the whole class: run_update
+    does not repeat `-c`, so if main_.cpp ever reads `params.n_ctx` here it would
+    see common_params' default (far above LOAD_CTX) and silently accept a prompt
+    that cannot fit the real context.
+
+    With LOAD_CTX=512 the guard is `embd_inp.size() > n_ctx - 4`, so a prompt of
+    hundreds of tokens must be rejected with a message naming 508.
+    """
+    resp = _run(network, CACHE_BATCH, LONG_PROMPT, "1")
+    _assert_no_trap(resp, "run_update with an over-long prompt")
+    assert "prompt is too long" in resp, (
+        "The over-long prompt was NOT rejected, so the context guard is using a "
+        f"stale params.n_ctx instead of llama_n_ctx(ctx)={LOAD_CTX}.\n{resp}"
+    )
+    assert f"max {LOAD_CTX - 4}" in resp, (
+        f"Rejected, but not against the loaded context size ({LOAD_CTX} - 4).\n{resp}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Class 1: upstream's try/catch is dead here.
+# Guards ICPP-PATCH item 5 (discard-before-load, re-stamp-after-save).
+# ---------------------------------------------------------------------------
+def test__unreadable_prompt_cache_self_heals(network: str) -> None:
+    """A prompt cache this build cannot read must be discarded, not trapped on.
+
+    Upstream handles a bad session file by catching and returning false
+    (llama_state_load_file). In the canister that catch is a no-op and the throw
+    is a trap — so main_.cpp must validate BEFORE calling in, discard the file,
+    and start cold.
+
+    We create the unreadable cache by uploading bytes that are not a session
+    file. That covers exactly the same code path as the real-world trigger (a
+    cache written by a different model, which threw `wrong model arch: 'llama'
+    instead of 'qwen3'`), without needing two models uploaded at once.
+    """
+    _call(
+        network,
+        "remove_prompt_cache",
+        f'(record {{ args = vec {{"--prompt-cache"; "{CACHE_FOREIGN}"}} }})',
+    )
+    upload = _call(
+        network,
+        "upload_prompt_cache_chunk",
+        f'(record {{ promptcache = "{CACHE_FOREIGN}"; chunk = blob "\\de\\ad\\be\\ef\\01\\02\\03\\04"; '
+        f"chunksize = 8 : nat64; offset = 0 : nat64; }})",
+    )
+    assert "Ok" in upload, upload
+
+    resp = _run(network, CACHE_FOREIGN, "Joe loves writing stories", "1")
+    _assert_no_trap(resp, "run_update on an unreadable prompt cache")
+    assert "(variant { Ok" in resp, (
+        "An unreadable prompt cache was not self-healed. The "
+        "prompt_cache_discard_if_stale() call before llama_state_load_file in "
+        f"src/main_.cpp was most likely lost.\n{resp}"
+    )
+    assert _cached(resp) == 0, f"expected a cold start after discarding: {resp}"
+
+
+def test__discarded_prompt_cache_is_restamped(network: str, principal: str) -> None:
+    """After a discard, the fresh cache must be re-stamped and then REUSED.
+
+    Without the prompt_cache_write_format_stamp() call after
+    llama_state_save_file, the cache written by the previous test would be
+    unstamped, so every later call would discard it again — a permanent cold
+    start that silently destroys prompt-cache performance without ever failing.
+
+    Asserted two ways, so this test stands on its own rather than only failing
+    as a knock-on from the previous one:
+      (a) STRUCTURAL — the ".icppfmt" sidecar exists, i.e. the stamp was written;
+      (b) BEHAVIOURAL — the next call actually reuses the cache (cached > 0).
+    """
+    # (a) the stamp file itself must have been (re)written next to the cache
+    sidecar = f".canister_cache/{principal}/sessions/{CACHE_FOREIGN}.icppfmt"
+    stamp = _call(
+        network, "filesystem_file_size", f'(record {{filename = "{sidecar}"}})'
+    )
+    assert "exists = true" in stamp, (
+        f"No prompt-cache format stamp at {sidecar}. The "
+        "prompt_cache_write_format_stamp() call after llama_state_save_file in "
+        f"src/main_.cpp was most likely lost, so this cache will be discarded "
+        f"again on every call — a permanent cold start.\n{stamp}"
+    )
+
+    # (b) and the cache must therefore actually be reused on the next call
+    resp = _run(network, CACHE_FOREIGN, "Joe loves writing stories", "1")
+    _assert_no_trap(resp, "second run_update on the re-created prompt cache")
+    assert "(variant { Ok" in resp, resp
+    assert _cached(resp) > 0, (
+        "The prompt cache was discarded a SECOND time, so it is never being "
+        "re-stamped. The prompt_cache_write_format_stamp() call after "
+        f"llama_state_save_file in src/main_.cpp was most likely lost.\n{resp}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# copy_prompt_cache must carry the format/model stamp with the bytes.
+#
+# These assert on the INGESTED-TOKEN COUNT, not just "it still works": a cache
+# that is silently discarded still returns correct output, it just re-ingests
+# the whole conversation. That is a pure performance regression with no error
+# anywhere — at max_tokens_update=4 a restored 256-token conversation costs ~64
+# extra run_update round-trips — so only a token-count assertion catches it.
+# ---------------------------------------------------------------------------
+def test__copy_restore_keeps_the_cache_warm(network: str) -> None:
+    """save -> remove -> restore must NOT re-ingest the conversation.
+
+    The documented save/restore flow (README "Prompt Caching"):
+        copy live -> save ; remove live ; copy save -> live
+    The stamp describes the BYTES, so it has to travel with them. Without that,
+    the restored cache is unstamped, gets discarded on first use, and every
+    restore silently pays a full re-ingestion.
+    """
+    for cache in (CACHE_LIVE, CACHE_SAVE):
+        _call(
+            network,
+            "remove_prompt_cache",
+            f'(record {{ args = vec {{"--prompt-cache"; "{cache}"}} }})',
+        )
+    assert "Ok" in _call(
+        network,
+        "new_chat",
+        f'(record {{ args = vec {{"--prompt-cache"; "{CACHE_LIVE}"}} }})',
+    )
+
+    _ingest_fully(network, CACHE_LIVE, WARM_PROMPT)
+    cached_before = _warm_reading(network, CACHE_LIVE, WARM_PROMPT)
+    assert cached_before > 0, "the cache never went warm to begin with"
+
+    # save, drop the live cache, restore over the same name
+    assert "Ok" in _copy_cache(network, CACHE_LIVE, CACHE_SAVE)
+    assert "Ok" in _call(
+        network,
+        "remove_prompt_cache",
+        f'(record {{ args = vec {{"--prompt-cache"; "{CACHE_LIVE}"}} }})',
+    )
+    assert "Ok" in _copy_cache(network, CACHE_SAVE, CACHE_LIVE)
+    assert "Ok" in _call(
+        network,
+        "new_chat",
+        f'(record {{ args = vec {{"--prompt-cache"; "{CACHE_LIVE}"}} }})',
+    )
+
+    cached_after = _warm_reading(network, CACHE_LIVE, WARM_PROMPT)
+    assert cached_after == cached_before, (
+        f"Restoring the cache changed the number of cached prompt tokens "
+        f"({cached_before} -> {cached_after}), i.e. the conversation had to be "
+        f"re-ingested. copy_prompt_cache is not carrying the .icppfmt stamp "
+        f"(prompt_cache_copy_stamp in src/promptcache.cpp)."
+    )
+
+
+def test__copy_to_a_fresh_name_keeps_the_cache_warm(network: str) -> None:
+    """Branching a conversation to a NEVER-USED name must also stay warm.
+
+    copy_prompt_cache has never carried the stamp, in any version. Whether that
+    showed up depended on the flow:
+
+      copy -> new_chat -> run_update : cold since v0.12.0 (when stamping was
+          added in the b10076 upgrade). new_chat has always discarded an
+          unstamped cache, and a fresh destination has no stamp — so a branch
+          was ALWAYS re-ingested. This test uses that flow.
+      copy -> run_update (no new_chat) : warm until v0.16.1, cold from v0.16.2,
+          which added the same discard to run_update.
+
+    Copying to a name that was used before could still come out warm by
+    accident, because the previous cache's orphaned stamp was left behind and
+    vouched for the new bytes. v0.16.3 stops relying on that accident.
+    """
+    _call(
+        network,
+        "remove_prompt_cache",
+        f'(record {{ args = vec {{"--prompt-cache"; "{CACHE_BRANCH}"}} }})',
+    )
+    cached_before = _warm_reading(network, CACHE_LIVE, WARM_PROMPT)
+
+    assert "Ok" in _copy_cache(network, CACHE_LIVE, CACHE_BRANCH)
+    assert "Ok" in _call(
+        network,
+        "new_chat",
+        f'(record {{ args = vec {{"--prompt-cache"; "{CACHE_BRANCH}"}} }})',
+    )
+
+    cached_branch = _warm_reading(network, CACHE_BRANCH, WARM_PROMPT)
+    assert cached_branch == cached_before, (
+        f"A conversation branched to a fresh cache name re-ingested its prompt "
+        f"({cached_before} -> {cached_branch} cached tokens). The branch is not "
+        f"inheriting the .icppfmt stamp from the cache it was copied from."
+    )


### PR DESCRIPTION
Follow-up to #30. Adds the regression tests that guard the two bug classes a
llama.cpp upgrade re-introduces — and those tests immediately found two more
defects in the #30 fix, both fixed here.

## The stamp must track the BYTES it describes

#30 made the `.icppfmt` sidecar authoritative: `prompt_cache_discard_if_stale()`
trusts it to decide whether a cache is safe to hand to llama.cpp. But nothing kept
the stamp in sync with the file it describes.

**1. Orphaned stamp -> a trap (found by the new pytest tests).**
`remove_prompt_cache()` and `upload_prompt_cache_chunk()` replaced or removed the
cache bytes but left the sidecar behind. A foreign cache could then sit behind a
stamp still claiming "written by this build with this model", so the discard never
fired and llama.cpp threw on bytes this build never wrote — i.e. the same
`IC0503` trap #30 set out to fix. Reachable in production: `upload_prompt_cache_chunk`
exists precisely to restore a downloaded cache.

Both now call `prompt_cache_remove_stamp()`, so replaced bytes are unstamped and
discarded on first use. One cold start beats a trap.

**2. copy_prompt_cache dropped the stamp -> a silent cold start (found by the
existing native exact-token tests).**
`copy_prompt_cache()` copies the cache bytes but never copied the sidecar, so a
restored or branched conversation was discarded and fully re-ingested — correct
output, no error, just a large silent cost. At `max_tokens_update = 4` a restored
256-token conversation is ~64 extra `run_update` round-trips.

`prompt_cache_copy_stamp()` now carries the stamp with the bytes: a copied cache
really was written by this build with this model, so the stamp stays valid.

History of this one, since it is older than #30:

| flow | before |
| ---- | ------ |
| `copy` -> `new_chat` -> `run_update` | cold since **v0.12.0**, when stamping was added — `new_chat` has always discarded an unstamped cache and a fresh destination has no stamp |
| `copy` -> `run_update` (no `new_chat`) | warm until v0.16.1, cold from **v0.16.2**, which added the same discard to `run_update` |

Copying onto a previously-used name could still come out warm *by accident*, because
the old cache's orphaned stamp vouched for the new bytes. That accident is what
masked this for so long — and removing it (fix 1) is what exposed it.

## New: test/test_upgrade_regressions.py (7 tests)

`src/main_.cpp` is a port of upstream's `tools/completion/completion.cpp`, re-done on
every llama.cpp upgrade, carrying ~93 `ICPP-PATCH` markers. Patches have been silently
dropped in a re-port before (b10076 lost `use_mmap` and warmup — README-0003, Bugs
0003 #3/#4), surfacing only as runtime traps on a replica.

| test | guards |
| ---- | ------ |
| `max_tokens_above_loaded_batch_does_not_trap` | decode sized from `llama_n_batch(ctx)`, not `params.n_batch` |
| `ctx_size_is_taken_from_the_context_not_params` | class-2 canary: over-long prompt rejected against the LOADED ctx |
| `unreadable_prompt_cache_self_heals` | discard before `llama_state_load_file` |
| `discarded_prompt_cache_is_restamped` | re-stamp after `llama_state_save_file` (structural + behavioural) |
| `copy_restore_keeps_the_cache_warm` | save/restore does not re-ingest |
| `copy_to_a_fresh_name_keeps_the_cache_warm` | branching does not re-ingest |

The copy tests assert on **ingested-token counts** (`n_prompt_tokens_decoded == 0`
and `n_prompt_tokens_cached` unchanged), because a discarded cache still produces
correct output — only a token-count assertion catches the regression.

**These are pytest, not native, deliberately.** The native build cannot reproduce
either failure: it has working exceptions (so the trap degrades to a clean `Err`)
and no instruction limit. Native tests here would pass forever while the bug was
live — exactly how the b10076 patches were lost.

Every failure message names the specific `ICPP-PATCH` likely lost and points at the
contributors guide.

## Docs: README-contributors-guide.md

New section "Two classes of bug that upstream does NOT have — re-check both on every
upgrade", covering (1) the WASI exception shim making upstream's `try`/`catch` dead,
with the seven catch-and-return-error entry points at b10076, and (2) the
`llama_context` outliving its `common_params`. Each has a grep to run on the next
upgrade, a table of context accessors vs the per-call fields they must not be read
from, and the checklist of `main_.cpp` patches to re-apply after a re-port.

Also records the diagnostic that saved the most time: `IC0503` = a C++ throw (with a
readable payload), `IC0502` = a failed `GGML_ASSERT` or a real memory fault.

## Verification

- `make all-tests` green: `all-static`, full wasm QA (all suites, incl. **7/7** new
  regression tests), `test-llm-native` **118/118**
- the 5 original regression tests were validated against a deliberately broken build
  (all three `main_.cpp` patches reverted): each failed with its intended diagnostic
- the two copy tests are validated by the native exact-token suite, which failed on
  exactly this invariant (`n_prompt_tokens_cached` 16 -> 0) before `copy_stamp` and
  passes after