### PR TITLE
Restore --ctx-size 16384 on Qwen3-1.7B: split large CPU buffers so KV memsets fit an IC slice

### DIFF
--- a/.icp/data/mappings/production.ids.json
+++ b/.icp/data/mappings/production.ids.json
@@ -1,4 +1,5 @@
 {
   "llama_cpp": "6uo7o-dyaaa-aaaag-ay5ha-cai",
-  "llama_cpp_qwen25": "6uwoh-vaaaa-aaaag-amema-cai"
+  "llama_cpp_qwen25": "6uwoh-vaaaa-aaaag-amema-cai",
+  "llama_cpp_qwen3_17b": "ndty5-lqaaa-aaaag-ay6cq-cai"
 }

--- a/README-contributors-guide.md
+++ b/README-contributors-guide.md
@@ -107,6 +107,42 @@ is clean but the IC traps, suspect the DEPLOY PIPELINE (stale `.icp/cache` cache
 not the binary. In b10076, a multi-hour "install trap" chase was ultimately the deploy pipeline installing a
 stale cached wasm.
 
+### Gate 0: plain llama.cpp on the host, for fast iteration
+
+Before any of the four gates above, remember the vendored fork is just llama.cpp — you can build
+and run its normal `llama-cli` / `llama-server` on your machine, against the same gguf files in
+`models/`. No canister, no replica, no 20-minute wasm build, and you get llama.cpp's full logging
+at native speed.
+
+Use it whenever the question is "what does llama.cpp actually do here?" rather than "how does the
+IC react to it?" — model/context/KV behaviour, allocation sizes and counts, tokenization, sampler
+behaviour, what a flag changes. It is far faster than instrumenting the canister for the same
+answer.
+
+```bash
+cd src/llama_cpp_onicai_fork
+cmake -B build && cmake --build build -j        # or: make
+./build/bin/llama-cli -m ../../models/Qwen/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q4_K_M.gguf \
+    -c 16384 --batch-size 8 --ubatch-size 8 --cache-type-k q8_0 --cache-type-v q8_0 -v -p "hi"
+```
+
+`-v` (`--verbose`, sets verbosity to INT_MAX) is the flag that turns on llama.cpp's INFO logging —
+`llama_context: n_ctx`, `llama_kv_cache: CPU KV buffer size = ... MiB`, `graph_reserve`,
+`sched_reserve`, and so on. Those lines are how the KV allocation was sized and counted during the
+IC0522 investigation.
+
+The same `-v` works through `load_model` on a canister, which is how to get those lines out of a
+replica — but note the canister's log ring defaults to 4 KiB and needs raising first:
+
+```bash
+icp canister settings update <canister> --log-memory-limit 2mib -n ic   # max 2 MiB
+icp canister logs <canister> -n ic                                       # controller-only
+```
+
+Canister log records are FRAGMENTS of lines and must be reassembled in `index` order to be
+readable. Logs survive a rejected message (you see how far execution got, which is often the whole
+diagnosis), but the ring is small, so capture right after the call.
+
 ## Two classes of bug that upstream does NOT have — re-check both on every upgrade
 
 These are not llama.cpp bugs, so there is nothing to send upstream. They exist only because

--- a/README-qwen3-1.7B.md
+++ b/README-qwen3-1.7B.md
@@ -92,6 +92,7 @@ Quantize both K and V caches and keep the micro-batch small:
 icp canister call llama_cpp -e local load_model '(record {
   args = vec {
     "--model"; "models/model.gguf";
+    "--no-warmup";
     "-c"; "16384";
     "--batch-size"; "8";
     "--ubatch-size"; "8";
@@ -103,7 +104,22 @@ icp canister call llama_cpp -e local load_model '(record {
 ```
 
 You can watch the heap with the `get_memory_status` query (see main README) — it
-should report ~2.07 GiB used after load.
+should report **~2.04 GiB** used after load.
+
+**`--no-warmup` is worth ~316 MiB of permanent headroom.** Warmup runs a dummy decode
+whose transient peak is far above what normal inference needs, and because wasm linear
+memory never shrinks, that peak becomes the canister's permanent high-water. Measured on
+mainnet at `-c 16384`, from a fresh heap each time:
+
+| load | heap after load |
+| ---- | --------------- |
+| with `--no-warmup` | 2_187_264_000 (**2.04 GiB**) |
+| without | 2_518_351_872 (2.35 GiB) |
+
+The memory is saved, not merely deferred: after `--no-warmup`, running a real
+`new_chat` + `run_update` left the heap unchanged at 2_187_264_000. (Verified with
+`--batch-size 8` and `max_tokens_update = 4`; a much larger batch could still reach the
+warmup peak.)
 
 > **`-c 16384` requires v0.16.4 or later.** Between 2026-07-30 and v0.16.4 this load
 > was rejected on mainnet with

--- a/README-qwen3-1.7B.md
+++ b/README-qwen3-1.7B.md
@@ -105,6 +105,26 @@ icp canister call llama_cpp -e local load_model '(record {
 You can watch the heap with the `get_memory_status` query (see main README) — it
 should report ~2.07 GiB used after load.
 
+> **`-c 16384` requires v0.16.4 or later.** Between 2026-07-30 and v0.16.4 this load
+> was rejected on mainnet with
+> `IC0522: ... large memory operation that used 4_1xx_xxx_xxx instructions and exceeded
+> the slice limit 2_000_000_000`, and `-c 4096` was the stopgap.
+>
+> Cause: an IC platform change (`dfinity/ic` `b7225383e` / `#10789`, the deterministic
+> memory tracker) made every touched 4 KiB page cost ~10 000 instructions (5 000
+> `accessed` + 5 000 `dirty`; heap writes used to be 1 000 and heap reads free). Zeroing
+> the KV cache is a single `memset` the IC cannot interrupt, so its whole cost lands in
+> one slice. At `-c 16384` that is ~2.44 B instructions — more than a full 2 B slice,
+> and over the 4 B carry-over allowance whenever it happens to start late in a slice.
+> (That timing dependence is why the failure was *not* monotonic in `--ctx-size`:
+> `-c 24576` loaded fine while `-c 16384` failed, reproducibly.)
+>
+> Fix in v0.16.4: the CPU buffer type now reports a 128 MiB `get_max_size`
+> (`ggml-backend.cpp`, `#ifdef __wasi__`), so llama.cpp's own
+> `ggml_backend_alloc_ctx_tensors_from_buft()` splits the KV cache into several buffers
+> whose `clear()` does one `memset` each — giving the scheduler a pause point between
+> them. Verified on mainnet.
+
 ## Set max_tokens
 
 ```bash
@@ -120,8 +140,8 @@ your app must loop `run_update` more times per response than with the 0.6B.
 
 ### Measured ceilings
 
-Probed on a local replica (same 40 B instruction limit as mainnet) with the load
-settings above — `-c 4096 --batch-size 8 --ubatch-size 8`, dual q8_0 KV — walking
+Probed on a local replica (same 40 B instruction limit as mainnet) at
+**`-c 4096` `--batch-size 8 --ubatch-size 8`, dual q8_0 KV** — walking
 `max_tokens_update` up until the call is rejected with `IC0522`:
 
 | Phase                          | highest value that worked | first value rejected |
@@ -131,10 +151,19 @@ settings above — `-c 4096 --batch-size 8 --ubatch-size 8`, dual q8_0 KV — wa
 
 Ingestion is cheaper per token than generation, which is why its ceiling is higher.
 
-**These were measured at a short context (~20–30 tokens).** The per-token cost grows
-with the KV span, so both ceilings *shrink* as a conversation gets longer. That is
-why **4** — not the measured maximum — is the recommended setting: it has to hold for
-the whole conversation, not just the first call.
+**These were measured at a short context (~20–30 tokens), at `-c 4096`.** Two things
+make them shrink:
+
+- The per-token cost grows with the KV span, so both ceilings drop as a conversation
+  gets longer.
+- **At a larger `--ctx-size` they drop again**, because `run_update` clears the whole
+  KV cache on every call (`llama_memory_clear(mem, true)` in `main_.cpp`). That costs
+  roughly 10 000 instructions per 4 KiB page of KV: **~0.61 B per call at `-c 4096`**
+  but **~2.44 B at `-c 16384`** — spent before a single token is decoded. Re-measure
+  the ceiling if you run at a larger context.
+
+That is why **4** — not the measured maximum — is the recommended setting: it has to
+hold for the whole conversation, at whatever context you loaded.
 
 If you want the extra throughput, `max_tokens_update` is a normal setting you can
 change between phases. Ingesting a long system prompt at 8 halves the round-trips:

--- a/icp.yaml
+++ b/icp.yaml
@@ -20,6 +20,16 @@ canisters:
       steps:
         - type: pre-built
           path: build/llama_cpp.wasm
+  # Our own Qwen3-1.7B canister, so experiments on the larger model do not have
+  # to borrow ICGPT's production canister (as the IC0522 slice-overrun
+  # investigation had to). Same wasm; it differs only in which gguf is uploaded
+  # and the settings it is given (3.75 GiB wasm_memory_limit, max_tokens 4).
+  # See README-qwen3-1.7B.md.
+  - name: llama_cpp_qwen3_17b
+    build:
+      steps:
+        - type: pre-built
+          path: build/llama_cpp.wasm
 
 networks:
   # A project-local replica, started with `icp network start`. icp-cli runs one

--- a/test/test_upgrade_regressions.py
+++ b/test/test_upgrade_regressions.py
@@ -43,6 +43,15 @@ CANISTER_NAME = "llama_cpp"
 
 MODEL = "models/tiny.gguf"
 
+# The vendored fork is a SEPARATE repo (onicai/llama_cpp_onicai_fork, branch
+# `onicai`) re-vendored on every llama.cpp upgrade, so patches in it are at risk
+# of being silently dropped -- exactly as b10076 lost the use_mmap and warmup
+# patches (README-0003-305ba519.md, Bugs #3/#4).
+GGML_BACKEND_CPP = (
+    Path(__file__).parent
+    / "../src/llama_cpp_onicai_fork/ggml/src/ggml-backend.cpp"
+)
+
 # The whole point: load with a batch far below the max_tokens used later, so the
 # context's n_batch and common_params' 2048 default are unmistakably different.
 LOAD_BATCH = 8
@@ -169,6 +178,59 @@ def _run(network: str, cache: str, prompt: str, n: str) -> str:
         + '"; "-n"; "'
         + n
         + '"} })',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Class 3: a patch in the vendored fork, lost on re-vendor.
+# Guards the CPU-buffer get_max_size split (fixes IC0522 at large --ctx-size).
+# ---------------------------------------------------------------------------
+def test__cpu_buffer_max_size_patch_is_present() -> None:
+    """The CPU buffer type must cap buffer size, so big memsets get split.
+
+    WHY THIS IS A SOURCE CHECK AND NOT A BEHAVIOURAL TEST
+    -----------------------------------------------------
+    The split cannot be observed at runtime from outside the canister:
+
+      * native never splits -- get_max_size returns SIZE_MAX off-WASI by design,
+        so n_buffers is always 1 there;
+      * the local replica cannot fail either way -- it runs at
+        dirty_page_overhead = 1000 (its network-launcher predates dfinity/ic
+        b7225383e), where the ceiling is ~5x higher than mainnet's and
+        unreachable in a wasm32 heap;
+      * the split is invisible in the logs -- llama.cpp prints
+        `ggml_backend_buffer_name(buf)`, which resolves to the BUFFER TYPE's
+        name ("CPU") for a multi_buffer too, and the size it prints is the
+        total either way.
+
+    So a behavioural test would pass with or without the fix, i.e. it could
+    never go red -- which makes it worthless as a regression test. The failure
+    mode actually worth guarding is the patch being dropped when the fork is
+    re-vendored, and that is exactly what this checks.
+
+    If this fails: re-apply the ICPP-PATCH in ggml-backend.cpp, or Qwen3-1.7B at
+    --ctx-size 16384 will again be rejected on mainnet with IC0522 "large memory
+    operation ... exceeded the slice limit". See
+    TMP-fix-load-model-large-ctx-ic0522.md.
+    """
+    assert GGML_BACKEND_CPP.exists(), f"vendored fork missing: {GGML_BACKEND_CPP}"
+    src = GGML_BACKEND_CPP.read_text(encoding="utf-8")
+
+    assert "ggml_backend_cpu_buffer_type_get_max_size" in src, (
+        "The ICPP-PATCH that bounds CPU buffer size is GONE from the vendored "
+        "fork -- most likely dropped in a re-vendor. Without it "
+        "ggml_backend_alloc_ctx_tensors_from_buft() never splits, the whole KV "
+        "cache is cleared by one memset, and load_model at a large --ctx-size "
+        "is rejected with IC0522 on mainnet."
+    )
+
+    # ...and it must actually be wired into the buffer type, not merely defined.
+    assert re.search(
+        r"\.get_max_size\s*=\s*\*/\s*ggml_backend_cpu_buffer_type_get_max_size", src
+    ), (
+        "ggml_backend_cpu_buffer_type_get_max_size() exists but is NOT wired "
+        "into ggml_backend_cpu_buffer_type's iface (.get_max_size), so it has "
+        "no effect."
     )
 
 


### PR DESCRIPTION
Since 2026-07-30, `load_model` for Qwen3-1.7B at `--ctx-size 16384` has been rejected on
mainnet, forcing ICGPT onto a `-c 4096` stopgap:

```
IC0522: Canister attempted to perform a large memory operation that used
4_1xx_xxx_xxx instructions and exceeded the slice limit 2_000_000_000.
```

**Fixed and verified on mainnet.** `-c 16384` loads again.

> Requires the matching fork commit `6bd774370` on `onicai/llama_cpp_onicai_fork`
> (branch `onicai`), which is already pushed — CI checks the fork out at `ref: onicai`.

## Cause

An IC platform change, not this repo: `dfinity/ic` `b7225383e` / `#10789` (deterministic
memory tracker) made every touched 4 KiB page cost ~10 000 instructions (5 000 `accessed`
+ 5 000 `dirty`; heap writes were 1 000, heap reads free).

Zeroing the KV cache is a single `memset` the IC cannot interrupt, so its whole cost lands
in one slice. DTS rejects a message once one uninterrupted stretch reaches
`slice_instruction_limit + max_slice_instruction_limit` = **4 B** instructions
(`rs/canister_sandbox/src/dts.rs`).

**It is a race against the slice boundary, not a size threshold.** The memset at `-c 16384`
costs ~2.44 B — more than one whole 2 B slice, but under the 4 B allowance — so it only
failed when it began late in a slice. That is why the failure was NOT monotonic in ctx:
measured on mainnet, back to back,

| ctx | KV | result |
| --- | -- | ------ |
| 16384 | 952 MiB | rejected (4.15 B, 4x reproducibly) |
| 20480 | 1190 MiB | rejected (5.01 B) |
| 24576 | 1428 MiB | **loaded fine** |

Pinpointed by running `load_model` with `-v` on mainnet and reading the canister log: it
stops exactly at `llama_kv_cache: CPU KV buffer size = 952.00 MiB`
(`llama-kv-cache.cpp:289`), and the next statement is the `ggml_backend_buffer_clear()` on
line 291.

## Fix

Use llama.cpp's own mechanism rather than hand-rolling a chunked memset. The CPU buffer
type now reports a 128 MiB `get_max_size` (`ggml-backend.cpp`, `#ifdef __wasi__`), so
`ggml_backend_alloc_ctx_tensors_from_buft()` splits the allocation into several buffers
wrapped in a `multi_buffer`, whose `clear()` does one `memset` per sub-buffer — giving DTS
a pause point between them. One 952 MiB memset becomes eight of ~0.33 B each, ~6x under the
2 B slice budget, so no starting position can matter.

This is a supported configuration upstream: both `llama-kv-cache.cpp:690` and
`llama-model.cpp:1715` already carry commented-out `get_base` asserts noting that
"multi_buffer does not have a defined base". I checked every `get_base` call that could
see a split buffer; the rest (`buf_output`, async-upload host buffers, mlock) are allocated
directly or unused on WASI.

`#ifdef __wasi__` keeps native behaviour bit-identical, so the 118 native exact-token
assertions remain a valid guard.

**This matters for inference, not just loading:** `main_.cpp` calls
`llama_memory_clear(mem, true)` at the start of every `run_update`/`run_query`, re-running
the same full-KV memset on every call.

## Verified on mainnet

| | before | after |
| --- | --- | --- |
| `load_model -c 16384` | rejected 4x, ~4.15 B | **"Model succesfully loaded into memory."** |
| wasm heap | — | 2_187_264_000 B (2.037 GiB), matching the pre-regression figure |

## Also in this PR

- **`test/test_upgrade_regressions.py`** — new `test__cpu_buffer_max_size_patch_is_present`.
  A source check, deliberately: the split cannot be observed at runtime (native never
  splits by design; the local replica runs at `dirty_page_overhead: 1000` where the ceiling
  is unreachable in wasm32; and `ggml_backend_buffer_name()` resolves to the buffer TYPE's
  name, so a multi_buffer still prints "CPU"). A behavioural test would pass with or without
  the fix and could never go red. The real risk is the patch being dropped in a fork
  re-vendor — as b10076 dropped the `use_mmap` and warmup patches — so that is what this
  guards. Validated: passes on current source, fails when the patch is dropped AND when the
  function survives but the `.get_max_size` wiring is lost.
- **`README-qwen3-1.7B.md`** — records that `-c 16384` needs v0.16.4+, with the cause and
  fix. Also corrects the measured `max_tokens` ceilings: they were taken at `-c 4096`, and
  at `-c 16384` the per-call KV clear costs ~2.44 B instead of ~0.61 B, so they must be
  re-measured at larger contexts.
- **`README-contributors-guide.md`** — adds "Gate 0": build and run plain `llama-cli` from
  the vendored fork for fast iteration, plus the `-v` verbosity flag and the canister
  log-ring techniques (raise `--log-memory-limit`; logs survive a rejected message) that
  located this bug.
- **`icp.yaml` + production id mapping** — new repo-scoped `llama_cpp_qwen3_17b`
  (`ndty5-lqaaa-aaaag-ay6cq-cai`), so future large-model experiments do not have to borrow
  ICGPT's production canister, as this investigation had to.

## Verification

`make all-tests` green: `all-static`, full wasm QA (all suites), `test-llm-native`
**118/118**. Plus the mainnet load above.

## Follow-up (not in this PR)

`TMP-optimize-per-call-kv-clear.md`: `llama_memory_clear(mem, true)` zeroes the entire KV
on every inference call — ~0.61 B instructions at `-c 4096`, ~2.44 B at `-c 16384`, spent
before any token is decoded. `clear(false)` may make it unnecessary; needs checking against
the `n_pad` padding region and guarding with the exact-token tests.